### PR TITLE
Add config defaults to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ The Script Extender adds Lua/Osiris scripting support to the game.
 
 The following configuration variables can be set in the `ScriptExtenderSettings.json` file:
 
-| Variable | Type | Description |
-|--|--|--|
-| CreateConsole | Boolean | Creates a console window that logs extender internals. Mainly useful for debugging. |
-| EnableLogging | Boolean | Enable logging of Osiris activity (rule evaluation, queries, etc.) to a log file. |
-| LogRuntime | Boolean | Log extender console and script output to a log file. |
-| LogCompile | Boolean | Log Osiris story compilation to a log file. |
-| LogFailedCompile | Boolean | Log errors during Osiris story compilation to a log file. |
-| LogDirectory | String | Directory where the generated Osiris logs will be stored. Default is `My Documents\OsirisLogs` |
-| EnableExtensions | Boolean | Make the Osiris extension functionality available ingame or in the editor. |
-| SendCrashReports | Boolean | Upload minidumps to the crash report collection server after a game crash. |
-| DumpNetworkStrings | Boolean | Dumps the NetworkFixedString table to `LogDirectory`. Mainly useful for debugging desync issues. |
-| DeveloperMode | Boolean | Enables various debug functionality for development purposes. |
-| DisableModValidation | Boolean | Disable module hashing when loading modules. |
-| EnableAchievements | Boolean | Re-enable achievements for modded games. |
-| EnableDebugger | Boolean | Enables the Osiris debugger interface |
-| DebuggerPort | Integer | Port number the Osiris debugger will listen on (default 9999) |
-| EnableLuaDebugger | Boolean | Enables the Lua debugger interface |
-| LuaDebuggerPort | Integer | Port number the Lua debugger will listen on (default 9998) |
+| Variable | Type | Default | Description |
+|--|--|--|--|
+| CreateConsole | Boolean | true | Creates a console window that logs extender internals. Mainly useful for debugging. |
+| EnableLogging | Boolean | false | Enable logging of Osiris activity (rule evaluation, queries, etc.) to a log file. |
+| LogRuntime | Boolean | false | Log extender console and script output to a log file. |
+| LogCompile | Boolean | false | Log Osiris story compilation to a log file. |
+| LogFailedCompile | Boolean | true | Log errors during Osiris story compilation to a log file. |
+| LogDirectory | String | `My Documents\OsirisLogs` | Directory where the generated Osiris logs will be stored. |
+| EnableExtensions | Boolean | true | Make the Osiris extension functionality available ingame or in the editor. |
+| SendCrashReports | Boolean | true | Upload minidumps to the crash report collection server after a game crash. |
+| ~~DumpNetworkStrings~~ | Boolean | Not implemented yet | Dumps the NetworkFixedString table to `LogDirectory`. Mainly useful for debugging desync issues. |
+| DeveloperMode | Boolean | false | Enables various debug functionality for development purposes. |
+| DisableModValidation | Boolean | true | Disable module hashing when loading modules. |
+| EnableAchievements | Boolean | true | Re-enable achievements for modded games. |
+| EnableDebugger | Boolean | false | Enables the Osiris debugger interface |
+| DebuggerPort | Integer | 9999 | Port number the Osiris debugger will listen on |
+| EnableLuaDebugger | Boolean | false | Enables the Lua debugger interface |
+| LuaDebuggerPort | Integer | 9998 | Port number the Lua debugger will listen on  |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following configuration variables can be set in the `ScriptExtenderSettings.
 
 | Variable | Type | Default | Description |
 |--|--|--|--|
-| CreateConsole | Boolean | true | Creates a console window that logs extender internals. Mainly useful for debugging. |
+| CreateConsole | Boolean | false | Creates a console window that logs extender internals. Mainly useful for debugging. |
 | EnableLogging | Boolean | false | Enable logging of Osiris activity (rule evaluation, queries, etc.) to a log file. |
 | LogRuntime | Boolean | false | Log extender console and script output to a log file. |
 | LogCompile | Boolean | false | Log Osiris story compilation to a log file. |


### PR DESCRIPTION
It would be useful to know which settings have which default, as the `ScriptExtenderSettings.json` file does not include any defaults when you download the extender.

This is based on my understanding of (quickly) reading `ExtenderConfig.h` and assuming that `OSI_EXTENSION_BUILD` is defined, as it is in the preprocessor definitions of the release build of the .vcxproj-file. Please check if any of it is wrong.

Also added that `DumpNetworkStrings` is not implemented as of the comment in `ServerNetwork.inl`, and since I couldn't find a config entry for it in `ExtenderConfig.h`

Also, I would suggest inverting `DisableModValidation` because it is confusing that this one setting suddenly has `true` for "disable", while all the others don't, but that's just me :D