### PR TITLE
Update Docs/Debugger.md with additional installation step and a QOL tip around VSCode Tasks

### DIFF
--- a/Docs/Debugger.md
+++ b/Docs/Debugger.md
@@ -27,7 +27,7 @@ Debugger::Debugger(): Starting Lua debugger
 Lua debugger listening on 127.0.0.1:9998; DBG protocol version 3
 ```
 
-To test your mod(s), place your ScriptExtender/ and meta.lsx files (not .pak'd) in `<Baldurs Gate 3 path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
+To test your mod(s), place your `ScriptExtender/` directory and `meta.lsx` (not .pak'd) in `<Baldurs Gate 3 path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
 
 <details>
 <summary>Creating symblink examples</summary>

--- a/Docs/Debugger.md
+++ b/Docs/Debugger.md
@@ -27,7 +27,7 @@ Debugger::Debugger(): Starting Lua debugger
 Lua debugger listening on 127.0.0.1:9998; DBG protocol version 3
 ```
 
-To test your mod(s), place your `ScriptExtender/` directory and `meta.lsx` (not .pak'd) in `<Baldurs Gate 3 path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
+To test your mod(s), place your `ScriptExtender/` directory and `meta.lsx` (not .pak'd) in `<BG3 Installation path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
 
 <details>
 <summary>Creating symblink examples</summary>

--- a/Docs/Debugger.md
+++ b/Docs/Debugger.md
@@ -27,7 +27,7 @@ Debugger::Debugger(): Starting Lua debugger
 Lua debugger listening on 127.0.0.1:9998; DBG protocol version 3
 ```
 
-To test your mod(s), place your `ScriptExtender/` directory and `meta.lsx` (not .pak'd) in `<BG3 Installation path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
+To test your mod(s), place your `ScriptExtender\` directory and `meta.lsx` (not .pak'd) in `<BG3 Installation path>\Data\Mods\<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
 
 <details>
 <summary>Creating symblink examples</summary>

--- a/Docs/Debugger.md
+++ b/Docs/Debugger.md
@@ -30,7 +30,7 @@ Lua debugger listening on 127.0.0.1:9998; DBG protocol version 3
 To test your mod(s), place your ScriptExtender/ and meta.lsx files (not .pak'd) in `<Baldurs Gate 3 path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
 
 <details>
-<summary>Examples</summary>
+<summary>Creating symblink examples</summary>
 	
 Windows CMD (Not Powershell):
 ```shell

--- a/Docs/Debugger.md
+++ b/Docs/Debugger.md
@@ -27,6 +27,23 @@ Debugger::Debugger(): Starting Lua debugger
 Lua debugger listening on 127.0.0.1:9998; DBG protocol version 3
 ```
 
+To test your mod(s), place your ScriptExtender/ and meta.lsx files (not .pak'd) in `<Baldurs Gate 3 path>/Data/Mods/<ModName>`. If you're using the [Recommended Mod structure](https://github.com/ShinyHobo/BG3-Modders-Multitool/wiki/Mod-Workspace-Structure), you can create a directory-type symblink to your vscode project's `<project-path>\Mods\<mod-name>` folder.
+
+<details>
+<summary>Examples</summary>
+	
+Windows CMD (Not Powershell):
+```shell
+ mklink /D "<BG3 Install Path>\Data\Mods\<ModName>" "<VSCodes Project Path>\Mods\<ModName>"
+```
+
+Unix Shell:
+```shell
+ln -s <VSCodes Project Path>/Mods/<ModName>/ <BG3 Install Path>/Data/Mods/
+```
+ 
+</details>
+
 ## Usage
 
 The debugger will attach to the running game, i.e. you should start the debug session (F5 key) after launching the game. If the game is not running or the extender debugger is not enabled, debug launch will fail with a `Could not connect to Lua debugger backend: No connection could be made [...]` error message.
@@ -40,3 +57,73 @@ Supported features:
  - Debug break on exception
  - Breakpoints are supported; conditional breakpoints and logpoints are not supported
  - Evaluating Lua code in console and inspecting the result of evaluated code
+
+## QOL
+You can configure VSCode to launch and kill the bg3.exe process, with arguments, and tie them to the startup and shutdown of your debugging instance via [Tasks](https://code.visualstudio.com/Docs/editor/tasks). This allows you to start and stop BG3 from within VSCode, attaching the debugger at the earliest possible point.
+<details>
+<summary>.vscode\tasks.json</summary>
+	
+```json 
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "bg3Continue",
+			"type": "shell",
+			"windows": {
+				"command": "Start-Process",
+				"args": [
+					"-FilePath",
+					"<BG3 Install Path>\\bin\\bg3.exe",
+					"-ArgumentList",
+					"-continueGame --skip-launcher", // Starts the last game you had loaded automagically
+					"-WorkingDirectory",
+					"<BG3 Install Path>\\bin"
+				],
+				"options": {
+					"shell": {
+						"executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+					}
+				},
+			}
+		},
+		{
+			"label": "bg3Kill",
+			"type": "shell",
+			"windows": {
+				"command": "taskkill",
+				"args": [
+					"/IM",
+					"bg3.exe"
+				],
+				"options": {
+					"shell": {
+						"executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+					}
+				},
+			}
+		}
+	]
+}
+```
+</details>
+
+<details>
+<summary>.vscode\launch.json</summary>
+<Section hyperlinks don't work inside a details block>
+	
+Follow process outlined in the [Installation Section](https://github.com/Norbyte/bg3se/blob/main/Docs/Debugger.md#installation) section first, then modify the configurations block to the include the following fields:
+	
+```json
+	...
+	"configurations": [
+		{
+			"preLaunchTask": "bg3Continue",
+			"postDebugTask": "bg3Kill",
+			"internalConsoleOptions": "openOnSessionStart",
+                        ...
+```
+
+</details>


### PR DESCRIPTION
Heya, was learning how to use the Debugger, thought of this "totally going to be easy" QOL Task idea, then spent the whole day getting it to work (on Windows)... so i figured I'd see if you're interested in including it to save others the trouble.

Also adds an Installation step around adding mod files to `Data/Mods/<modname>` just to make it clear to users, with an added tip around symlinks.

If you've got a tip around fixing breakpoints so that both exception and custom ones trigger, instead of just exception, i'll happily include that too! I tried adding `\bin\ScriptExtenderUpdaterConfig.json` `{"UpdateChannel": "Devel"}` per the Larian Discord and can see i'm running v10 + that DAP is sending them successfully to the debugger, but still a no-go unfortunately. If not, no worries!