### PR TITLE
Adds ShowError Utils

### DIFF
--- a/BG3Extender/IdeHelpers/ExtIdeHelpers.lua
+++ b/BG3Extender/IdeHelpers/ExtIdeHelpers.lua
@@ -6320,6 +6320,7 @@ function Ext_Types.GenerateIdeHelpers(outputPath, addOsi) end
 --- @field PrintError fun()
 --- @field PrintWarning fun()
 --- @field ShowErrorAndExitGame fun(a1:string)
+--- @field ShowError fun(a1:string)
 --- @field Version fun():int32
 local Ext_Utils = {}
 

--- a/BG3Extender/Lua/Libs/Utils.inl
+++ b/BG3Extender/Lua/Libs/Utils.inl
@@ -181,6 +181,11 @@ void ShowErrorAndExitGame(STDString message)
 	gExtender->GetLibraryManager().ShowStartupError(message, true);
 }
 
+void ShowError(STDString message)
+{
+	gExtender->GetLibraryManager().ShowStartupError(message, true, false);
+}
+
 GlobalSwitches* GetGlobalSwitches()
 {
 	return GetStaticSymbols().GetGlobalSwitches();
@@ -228,6 +233,7 @@ void RegisterUtilsLib()
 	MODULE_FUNCTION(HandleToInteger)
 	MODULE_FUNCTION(IntegerToHandle)
 	MODULE_FUNCTION(ShowErrorAndExitGame)
+	MODULE_FUNCTION(ShowError)
 	MODULE_FUNCTION(GetGlobalSwitches)
 	MODULE_FUNCTION(GetCommandLineParams)
 	END_MODULE()

--- a/BG3Extender/Lua/Libs/Utils.inl
+++ b/BG3Extender/Lua/Libs/Utils.inl
@@ -183,7 +183,7 @@ void ShowErrorAndExitGame(STDString message)
 
 void ShowError(STDString message)
 {
-	gExtender->GetLibraryManager().ShowStartupError(message, true, false);
+	gExtender->GetLibraryManager().ShowStartupError(message, false);
 }
 
 GlobalSwitches* GetGlobalSwitches()


### PR DESCRIPTION
Allows calling the ShowStartupError popup without exiting the game. It also sets the `wait` parameter to `true` so it can be called before the popup is available