### PR TITLE
Multiplayer `Kick` function

### DIFF
--- a/BG3Extender/Extender/Server/ServerNetworking.cpp
+++ b/BG3Extender/Extender/Server/ServerNetworking.cpp
@@ -149,6 +149,22 @@ void NetworkManager::Send(net::ExtenderMessage * msg, UserId userId)
 	}
 }
 
+void NetworkManager::Kick(UserId userId, const char* kickText)
+{
+	auto server = GetServer();
+
+	if (server != nullptr) {
+		auto kickMsg = GetFreeMessage();
+		auto kick = kickMsg->GetMessage().mutable_s2c_kick();
+
+		if (kickText != nullptr) {
+			kick->set_message(kickText);
+		}
+
+		server->SendMessageSingleRecipient(userId.Id, kickMsg);
+	}
+}
+
 void NetworkManager::Broadcast(net::ExtenderMessage * msg, UserId excludeUserId, bool excludeLocalPeer)
 {
 	auto server = GetServer();

--- a/BG3Extender/Extender/Server/ServerNetworking.h
+++ b/BG3Extender/Extender/Server/ServerNetworking.h
@@ -32,6 +32,7 @@ public:
 	net::GameServer* GetServer() const;
 
 	void Send(net::ExtenderMessage * msg, UserId userId);
+	void Kick(UserId userId, const char* kickText);
 	void Broadcast(net::ExtenderMessage * msg, UserId excludeUserId, bool excludeLocalPeer = false);
 	void BroadcastToConnectedPeers(net::ExtenderMessage* msg, UserId excludeUserId, bool excludeLocalPeer = false);
 

--- a/BG3Extender/Lua/Libs/ServerNet.inl
+++ b/BG3Extender/Lua/Libs/ServerNet.inl
@@ -67,6 +67,17 @@ std::optional<bool> PlayerHasExtender(lua_State* L, Guid characterGuid)
 	return networkMgr.CanSendExtenderMessages(character->UserID.GetPeerId());
 }
 
+void Kick(int userId, const char* kickText)
+{
+	if (UserId(userId) == ReservedUserId) {
+		OsiError("Attempted to send message to reserved user ID!");
+		return;
+	}
+
+	auto& networkMgr = gExtender->GetServer().GetNetworkManager();
+	networkMgr.Kick(UserId(userId), kickText);
+}
+
 void RegisterNetLib()
 {
 	DECLARE_MODULE(Net, Server)
@@ -75,6 +86,7 @@ void RegisterNetLib()
 	MODULE_FUNCTION(PostMessageToClient)
 	MODULE_FUNCTION(PostMessageToUser)
 	MODULE_FUNCTION(PlayerHasExtender)
+	MODULE_FUNCTION(Kick)
 	END_MODULE()
 }
 


### PR DESCRIPTION
Hey 👋, I wanted to make a multiplayer perma-death mod & needed a way to kick people so they're not stuck spectating the game when I make the dead character a NPC.

Only issue with `kickMsg->GetMessage().mutable_s2c_kick()` is that it seems to be a extender message, which is causing clients without extender to crash; Otherwise I'm open to suggestions if there's a better way to implement this, thanks.