### PR TITLE
Comparing versionText to see if append is necessary

### DIFF
--- a/BG3Extender/Extender/Client/ScriptExtenderClient.cpp
+++ b/BG3Extender/Extender/Client/ScriptExtenderClient.cpp
@@ -299,7 +299,7 @@ void ScriptExtender::ShowVersionNumber()
 {
 	RuntimeStringHandle rsh(FixedString("h5b6e4138g2cf0g4d67gb825gee416cf8c54f"));
 	auto versionText = GetStaticSymbols().GetTranslatedStringRepository()->GetTranslatedString(rsh);
-	if (versionText) {
+	if (versionText && !STDString(*versionText).contains("Script Extender")) {
 		auto expandedVersion = STDString(*versionText) +
 			"\r\nScript Extender v" + STDString(std::to_string(CurrentVersion)) + " loaded, built on " + BuildDate + ".";
 		GetStaticSymbols().GetTranslatedStringRepository()->UpdateTranslatedString(rsh, expandedVersion);


### PR DESCRIPTION
Sometimes the following UI issue occurs upon returning to the main screen with SE loaded:

![image](https://github.com/Norbyte/bg3se/assets/317485/82fb9674-68c9-44b3-828e-9142acd5aad6)


I believe this should prevent that from happening.