### PR TITLE
Async Osiris interface

### DIFF
--- a/BG3Extender/Extender/Server/ServerNetworking.cpp
+++ b/BG3Extender/Extender/Server/ServerNetworking.cpp
@@ -4,6 +4,25 @@
 
 BEGIN_NS(esv)
 
+namespace
+{
+	void OsirisQueryErrorResponse(net::MessageContext& context, const net::MessageWrapper& msg, const char* error, ...)
+	{
+		auto message = gExtender->GetServer().GetNetworkManager().GetFreeMessage();
+		auto response = message->GetMessage().mutable_s2c_osiris_query_response();
+		static char errorformatbuf[1024];
+		va_list args;
+		va_start(args, error);
+		vsnprintf(errorformatbuf, 1024, error, args);
+		va_end(args);
+		response->set_error(errorformatbuf);
+		response->set_responseid(msg.c2s_osiris_query().msgid());
+		gExtender->GetServer().GetNetworkManager().Send(message, context.UserID);
+	}
+}
+
+#define QUERY_ERROR(...) OsirisQueryErrorResponse(context, msg, __VA_ARGS__)
+
 net::ProtocolResult ExtenderProtocol::ProcessMsg(void* unused, net::MessageContext* context, net::Message* msg)
 {
 	auto base = ExtenderProtocolBase::ProcessMsg(unused, context, msg);
@@ -41,8 +60,159 @@ void ExtenderProtocol::ProcessExtenderMessage(net::MessageContext& context, net:
 		break;
 	}
 
+	case net::MessageWrapper::kC2SOsirisQuery:
+	{
+		// FIXME - not yet supported
+		auto const& query = msg.c2s_osiris_query();
+
+		if (!gExtender->GetCurrentExtensionState()->GetLua() || gExtender->GetCurrentExtensionState()->GetLua()->RestrictionFlags & lua::State::RestrictOsiris) {
+			QUERY_ERROR("Attempted to read Osiris database in restricted context");
+		}
+
+		switch (query.type())
+		{
+			case net::OsirisQueryType::OSIRIS_CALL:
+				QUERY_ERROR("Remote Osiris calls not (yet) supported!");
+				OsiErrorS("Remote Osiris calls not (yet) supported!");
+				break;
+			case net::OsirisQueryType::OSIRIS_DEFER:
+				QUERY_ERROR("Remote Osiris deferrals not (yet) supported!");
+				OsiErrorS("Remote Osiris deferrals not (yet) supported!");
+				break;
+			case net::OsirisQueryType::OSIRIS_DELETE:
+				QUERY_ERROR("Remote Osiris deletions not (yet) supported!");
+				OsiErrorS("Remote Osiris deletions not (yet) supported!");
+				break;
+			case net::OsirisQueryType::OSIRIS_GET:
+				ProcessOsirisGet(context, msg);
+				break;
+		}
+		break;
+	}
+
 	default:
 		OsiErrorS("Unknown extension message type received!");
+	}
+}
+
+void ExtenderProtocol::ProcessOsirisGet(net::MessageContext& context, net::MessageWrapper& msg)
+{
+	auto const& query = msg.c2s_osiris_query();
+
+	auto func = gExtender->GetServer().Osiris().LookupFunction(query.name().c_str(), query.num_args());
+	if (func != nullptr && func->Signature->OutParamList.numOutParams() == 0) {
+		if (func->Type == FunctionType::Database)
+		{
+			auto db = func->Node.Get()->Database.Get();
+
+			auto head = db->Facts.Head;
+			auto current = head->Next;
+
+			auto message = gExtender->GetServer().GetNetworkManager().GetFreeMessage();
+			auto response = message->GetMessage().mutable_s2c_osiris_query_response();
+			response->set_responseid(query.msgid());
+			response->set_succeeded(true);
+
+			std::vector<std::remove_reference_t<decltype(query.args()[0])>*> args(query.num_args(), nullptr);
+			for (int i = 0; i < query.args_size(); i++)
+			{
+				args[query.args(i).index()] = &query.args(i);
+			}
+
+			const auto check_match = [&args](TupleVec const& v){
+				for (int i = 0; i < v.Size; i++)
+				{
+					switch (gExtender->GetServer().Osiris().GetBaseType((ValueType)v.Values[i].TypeId))
+					{
+						case ValueType::Integer:
+							if (args[i] != nullptr &&
+								!(args[i]->val_case() == args[i]->kIntv && args[i]->intv() == v.Values[i].Value.Int32))
+							{
+								return false;
+							}
+							break;
+							
+						case ValueType::Integer64:
+							if (args[i] != nullptr &&
+								!(args[i]->val_case() == args[i]->kIntv && args[i]->intv() == v.Values[i].Value.Int64))
+							{
+								return false;
+							}
+							break;
+
+						case ValueType::Real:
+							if (args[i] != nullptr &&
+								!(args[i]->val_case() == args[i]->kNumv && abs(v.Values[i].Value.Float - args[i]->numv()) <= 0.00001f))
+							{
+								return false;
+							}
+							break;
+
+						case ValueType::String:
+						case ValueType::GuidString:
+							if (args[i] != nullptr &&
+								!(args[i]->val_case() == args[i]->kStrv && args[i]->strv() == v.Values[i].Value.String))
+							{
+								return false;
+							}
+							break;
+					}
+				}
+				return true;
+			};
+
+			while (current != head) {
+				if (check_match(current->Item)) {
+					auto result = response->add_results();
+					result->set_num_retvals((uint32_t)args.size());
+					for (int i = 0; i < args.size(); i++)
+					{
+						if (!args[i])
+						{
+							auto v = result->add_retvals();
+							v->set_index(i);
+							switch (gExtender->GetServer().Osiris().GetBaseType((ValueType)current->Item.Values[i].TypeId))
+							{
+								case ValueType::Integer:
+									v->set_intv(current->Item.Values[i].Value.Int32);
+									break;
+									
+								case ValueType::Integer64:
+									v->set_intv(current->Item.Values[i].Value.Int64);
+									break;
+
+								case ValueType::Real:
+									v->set_numv(current->Item.Values[i].Value.Float);
+									break;
+
+								case ValueType::String:
+								case ValueType::GuidString:
+									v->set_strv(current->Item.Values[i].Value.String);
+									break;
+								default:
+									OsiErrorS("Unhandled Osi TypedValue");
+									message->GetMessage().mutable_s2c_osiris_query_response()->set_succeeded(false);
+									message->GetMessage().mutable_s2c_osiris_query_response()->set_error("Unhandled Osi TypedValue");
+									goto sendtime; // Used as a multi-stage break;
+							}
+						}
+					}
+				}
+
+				current = current->Next;
+			}
+
+		sendtime:
+			gExtender->GetServer().GetNetworkManager().Send(message, context.UserID);
+		}
+		else
+		{
+			QUERY_ERROR("Function '%s(%d)' is not a database", query.name().c_str(), query.args());
+		}
+	}
+	else
+	{
+		QUERY_ERROR("No database named '%s(%d)' exists", query.name().c_str(), query.args());
 	}
 }
 

--- a/BG3Extender/Extender/Server/ServerNetworking.h
+++ b/BG3Extender/Extender/Server/ServerNetworking.h
@@ -13,6 +13,8 @@ public:
 
 protected:
 	void ProcessExtenderMessage(net::MessageContext& context, net::MessageWrapper& msg) override;
+
+	void ProcessOsirisGet(net::MessageContext& context, net::MessageWrapper& msg);
 };
 
 class NetworkManager

--- a/BG3Extender/Extender/Shared/ExtenderNet.h
+++ b/BG3Extender/Extender/Shared/ExtenderNet.h
@@ -12,8 +12,9 @@ public:
 	static constexpr uint32_t MaxPayloadLength = 0xfffff;
 
 	static constexpr uint32_t VerInitial = 1;
+	static constexpr uint32_t VerClientOsirisQuery = VerInitial + 1;
 	// Version of protocol, increment each time the protobuf changes
-	static constexpr uint32_t ProtoVersion = VerInitial;
+	static constexpr uint32_t ProtoVersion = VerClientOsirisQuery;
 
 	ExtenderMessage();
 	~ExtenderMessage() override;

--- a/BG3Extender/Extender/Shared/ExtenderProtocol.proto
+++ b/BG3Extender/Extender/Shared/ExtenderProtocol.proto
@@ -92,6 +92,45 @@ message MsgUserVars {
   repeated UserVar vars = 1;
 }
 
+message OsirisVal {
+  uint32 index = 1;
+  oneof val {
+    string strv = 2;
+    int64 intv = 3;
+    float numv = 4;
+  }
+}
+
+enum OsirisQueryType {
+  OSIRIS_GET = 0;
+  OSIRIS_CALL = 1;
+  OSIRIS_DELETE = 2;
+  OSIRIS_DEFER = 3;
+}
+
+// Notifies the server that the client requested an Osiris query
+message MsgC2SOsirisQuery {
+  uint32 msgid = 1;
+  string name = 2;
+  OsirisQueryType type = 3;
+  uint32 num_args = 4; // Full number of arguments, including null ones
+  repeated OsirisVal args = 5;
+}
+
+message OsirisResult {
+  uint32 num_retvals = 1;
+  repeated OsirisVal retvals = 2;
+}
+
+message MsgS2COsirisQueryResponse {
+  uint32 responseid = 1;
+  repeated OsirisResult results = 2;
+  oneof response {
+    bool succeeded = 3;
+    string error = 4;
+  }
+}
+
 message MessageWrapper {
   oneof msg {
     MsgPostLuaMessage post_lua = 1;
@@ -100,5 +139,7 @@ message MessageWrapper {
     MsgS2CSyncStat s2c_sync_stat = 6;
     MsgS2CKick s2c_kick = 7;
     MsgUserVars user_vars = 8;
+    MsgC2SOsirisQuery c2s_osiris_query = 9;
+    MsgS2COsirisQueryResponse s2c_osiris_query_response = 10;
   }
 }

--- a/BG3Extender/Extender/Shared/ThreadedExtenderState.inl
+++ b/BG3Extender/Extender/Shared/ThreadedExtenderState.inl
@@ -20,7 +20,7 @@ void ThreadedExtenderState::RemoveThread(DWORD threadId)
 
 void ThreadedExtenderState::EnqueueTask(std::function<void()> fun)
 {
-	threadTasks_.push(fun);
+	threadTasks_.push(std::move(fun));
 }
 
 void ThreadedExtenderState::SubmitTaskAndWait(std::function<void()> fun)

--- a/BG3Extender/Extender/Shared/Utils.h
+++ b/BG3Extender/Extender/Shared/Utils.h
@@ -13,19 +13,19 @@ BEGIN_SE()
 #if !defined(OSI_NO_DEBUG_LOG)
 #define LuaError(msg) { \
 	std::stringstream ss; \
-	ss << __FUNCTION__ "(): " msg; \
+	ss << __FUNCTION__ "(): " << msg; \
 	LogLuaError(ss.str()); \
 }
 
 #define OsiError(msg) { \
 	std::stringstream ss; \
-	ss << __FUNCTION__ "(): " msg; \
+	ss << __FUNCTION__ "(): " << msg; \
 	LogOsirisError(ss.str()); \
 }
 
 #define OsiWarn(msg) { \
 	std::stringstream ss; \
-	ss << __FUNCTION__ "(): " msg; \
+	ss << __FUNCTION__ "(): " << msg; \
 	LogOsirisWarning(ss.str()); \
 }
 

--- a/BG3Extender/Lua/Client/LuaBindingClient.h
+++ b/BG3Extender/Lua/Client/LuaBindingClient.h
@@ -4,6 +4,7 @@
 #if defined(ENABLE_UI)
 #include <Lua/Client/UIEvents.h>
 #endif
+#include <Lua/Client/LuaOsirisBinding.h>
 
 namespace bg3se::ecl::lua
 {
@@ -23,6 +24,14 @@ namespace bg3se::ecl::lua
 	public:
 		void Register(lua_State * L) override;
 		void RegisterLib(lua_State * L) override;
+
+	private:
+		static char const * const NameResolverMetatableName;
+
+		void RegisterNameResolverMetatable(lua_State * L);
+		void CreateNameResolver(lua_State * L);
+
+		static int LuaIndexResolverTable(lua_State* L);
 	};
 
 

--- a/BG3Extender/Lua/Client/LuaClient.cpp
+++ b/BG3Extender/Lua/Client/LuaClient.cpp
@@ -4,6 +4,7 @@
 #include <Lua/Shared/LuaModule.h>
 #include <Extender/ScriptExtender.h>
 #include <Extender/Client/ExtensionStateClient.h>
+#include <Lua/Client/LuaOsirisBinding.h>
 #include "resource.h"
 #if defined(ENABLE_UI)
 #include <Lua/Client/UIEvents.inl>
@@ -28,6 +29,9 @@ LifetimePool& GetClientLifetimePool()
 void ExtensionLibraryClient::Register(lua_State * L)
 {
 	ExtensionLibrary::Register(L);
+	AsyncOsiFunctionNameProxy::RegisterMetatable(L);
+	RegisterNameResolverMetatable(L);
+	CreateNameResolver(L);
 }
 
 void ExtensionLibraryClient::RegisterLib(lua_State * L)

--- a/BG3Extender/Lua/Client/LuaOsirisBinding.h
+++ b/BG3Extender/Lua/Client/LuaOsirisBinding.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Lua/LuaBinding.h>
+#include <GameDefinitions/Osiris.h>
+#include <Osiris/Shared/CustomFunctions.h>
+#include <Extender/Shared/ExtensionHelpers.h>
+#include <Osiris/Shared/OsirisHelpers.h>
+
+BEGIN_NS(ecl::lua)
+
+using namespace bg3se::lua;
+
+class AsyncOsiFunctionNameProxy : public Userdata<AsyncOsiFunctionNameProxy>, public Callable
+{
+public:
+	static char const * const MetatableName;
+	// Maximum number of OUT params that a query can return.
+	// (This setting determines how many function arities we'll check during name lookup)
+	static constexpr uint32_t MaxQueryOutParams = 6;
+
+	static void PopulateMetatable(lua_State * L);
+
+	AsyncOsiFunctionNameProxy(STDString const & name, class ClientState & state);
+
+	int LuaCall(lua_State * L);
+
+private:
+	static std::atomic<uint32_t> currentId;
+	STDString name_;
+	class ClientState & state_;
+
+	static int LuaGet(lua_State * L);
+	static int LuaDelete(lua_State * L);
+	static int LuaDeferredNotification(lua_State * L);
+	bool BeforeCall(lua_State * L);
+};
+
+END_NS()

--- a/BG3Extender/Lua/Helpers/LuaPush.h
+++ b/BG3Extender/Lua/Helpers/LuaPush.h
@@ -7,6 +7,11 @@ inline void push(lua_State* L, nullptr_t v)
 	lua_pushnil(L);
 }
 
+inline void push(lua_State* L, std::monostate v)
+{
+	lua_pushnil(L);
+}
+
 inline void push(lua_State* L, bool v)
 {
 	lua_pushboolean(L, v ? 1 : 0);

--- a/BG3Extender/Lua/LuaBinding.cpp
+++ b/BG3Extender/Lua/LuaBinding.cpp
@@ -157,6 +157,7 @@ namespace bg3se::lua
 	void ExtensionLibrary::Register(lua_State * L)
 	{
 		RegisterLib(L);
+		AsyncOsiFuture::RegisterMetatable(L);
 	}
 
 
@@ -434,6 +435,39 @@ namespace bg3se::lua
 		params.Payload = payload;
 		params.UserID = userId;
 		ThrowEvent("NetMessage", params);
+	}
+
+	AsyncOsiFuture* State::CreateOsirisFuture(uint32_t id)
+	{
+		auto ret = Userdata<AsyncOsiFuture>::New(L);
+		futureManager_.emplace(id, RegistryEntry(L, -1));
+		return ret;
+	}
+
+	void State::ResolveOsirisFuture(uint32_t id, std::string_view err)
+	{
+		auto found = futureManager_.find(id);
+		if (found != futureManager_.end())
+		{
+			found->second.Push();
+			auto future = AsyncOsiFuture::CheckUserData(L, -1);
+			future->Resolve(err);
+
+			futureManager_.erase(found);
+		}
+	}
+
+	void State::ResolveOsirisFuture(uint32_t id, Array<Array<std::variant<std::monostate, StringView, int64_t, float>>>& results)
+	{
+		auto found = futureManager_.find(id);
+		if (found != futureManager_.end())
+		{
+			found->second.Push();
+			auto future = AsyncOsiFuture::CheckUserData(L, -1);
+			future->Resolve(results);
+
+			futureManager_.erase(found);
+		}
 	}
 
 	STDString State::GetBuiltinLibrary(int resourceId)

--- a/BG3Extender/Lua/LuaBinding.cpp
+++ b/BG3Extender/Lua/LuaBinding.cpp
@@ -470,6 +470,19 @@ namespace bg3se::lua
 		}
 	}
 
+	void State::ResolveOsirisFuture(uint32_t id, std::span<const lua::PersistentRef> results, bool success)
+	{
+		auto found = futureManager_.find(id);
+		if (found != futureManager_.end())
+		{
+			found->second.Push();
+			auto future = AsyncOsiFuture::CheckUserData(L, -1);
+			future->Resolve(results, success);
+
+			futureManager_.erase(found);
+		}
+	}
+
 	STDString State::GetBuiltinLibrary(int resourceId)
 	{
 		auto resource = GetExeResource(resourceId);

--- a/BG3Extender/Lua/LuaBinding.h
+++ b/BG3Extender/Lua/LuaBinding.h
@@ -158,6 +158,7 @@ namespace bg3se::lua
 		class AsyncOsiFuture* CreateOsirisFuture(uint32_t id);
 		void ResolveOsirisFuture(uint32_t id, std::string_view err);
 		void ResolveOsirisFuture(uint32_t id, Array<Array<std::variant<std::monostate, StringView, int64_t, float>>>& results);
+		void ResolveOsirisFuture(uint32_t id, std::span<const lua::PersistentRef> ref, bool success);
 
 		template <class... Ret, class... Args>
 		bool CallExtRet(char const * func, uint32_t restrictions, std::tuple<Ret...>& ret, Args... args)
@@ -276,6 +277,8 @@ namespace bg3se::lua
 
 		void Resolve(std::string_view err);
 		void Resolve(Array<Array<std::variant<std::monostate, StringView, int64_t, float>>>& results);
+
+		void Resolve(std::span<const lua::PersistentRef> result, bool succeeded);
 	private:
 		std::vector<RegistryEntry> ThenList;
 		std::optional<RegistryEntry> Else;

--- a/BG3Extender/Lua/LuaBinding.h
+++ b/BG3Extender/Lua/LuaBinding.h
@@ -155,6 +155,9 @@ namespace bg3se::lua
 		virtual void OnUpdate(GameTime const& time);
 		void OnStatsStructureLoaded();
 		void OnNetMessageReceived(STDString const& channel, STDString const& payload, UserId userId);
+		class AsyncOsiFuture* CreateOsirisFuture(uint32_t id);
+		void ResolveOsirisFuture(uint32_t id, std::string_view err);
+		void ResolveOsirisFuture(uint32_t id, Array<Array<std::variant<std::monostate, StringView, int64_t, float>>>& results);
 
 		template <class... Ret, class... Args>
 		bool CallExtRet(char const * func, uint32_t restrictions, std::tuple<Ret...>& ret, Args... args)
@@ -212,6 +215,7 @@ namespace bg3se::lua
 		CachedUserVariableManager variableManager_;
 		CachedModVariableManager modVariableManager_;
 		EntityComponentEventHooks entityHooks_;
+		std::unordered_map<uint32_t, RegistryEntry> futureManager_;
 
 		void OpenLibs();
 		EventResult DispatchEvent(EventBase& evt, char const* eventName, bool canPreventAction, uint32_t restrictions);
@@ -256,6 +260,28 @@ namespace bg3se::lua
 		STDString Channel;
 		STDString Payload;
 		UserId UserID;
+	};
+
+	class AsyncOsiFuture : public Userdata<AsyncOsiFuture>
+	{
+	public:
+		static char const * const MetatableName;
+
+		static void PopulateMetatable(lua_State * L);
+
+		static AsyncOsiFuture* New(lua_State* L, uint32_t id)
+		{
+			return State::FromLua(L)->CreateOsirisFuture(id);
+		}
+
+		void Resolve(std::string_view err);
+		void Resolve(Array<Array<std::variant<std::monostate, StringView, int64_t, float>>>& results);
+	private:
+		std::vector<RegistryEntry> ThenList;
+		std::optional<RegistryEntry> Else;
+
+		static int LuaThen(lua_State * L);
+		static int LuaElse(lua_State * L);
 	};
 }
 

--- a/BG3Extender/Lua/Server/LuaBindingServer.h
+++ b/BG3Extender/Lua/Server/LuaBindingServer.h
@@ -240,11 +240,15 @@ namespace bg3se::esv::lua
 
 	private:
 		static char const * const NameResolverMetatableName;
+		static char const * const AsyncNameResolverMetatableName;
 
 		void RegisterNameResolverMetatable(lua_State * L);
 		void CreateNameResolver(lua_State * L);
+		void RegisterAsyncNameResolverMetatable(lua_State * L);
+		void CreateAsyncNameResolver(lua_State * L);
 
 		static int LuaIndexResolverTable(lua_State* L);
+		static int AsyncLuaIndexResolverTable(lua_State* L);
 	};
 
 	class ServerState : public State

--- a/BG3Extender/Lua/Server/LuaOsirisBinding.cpp
+++ b/BG3Extender/Lua/Server/LuaOsirisBinding.cpp
@@ -248,10 +248,10 @@ void OsirisCallbackManager::StorySetMerging(bool isMerging)
 
 void OsirisCallbackManager::RegisterNodeHandler(OsirisHookSignature const& sig, SubscriptionId handlerId)
 {
-	auto func = LookupOsiFunction(sig.name, sig.arity);
+	auto func = gExtender->GetServer().Osiris().LookupFunction(sig.name, sig.arity);
 	if (func != nullptr && func->Type == FunctionType::UserQuery) {
 		// We need to find the backing node for the user query
-		func = LookupOsiFunction(sig.name + "__DEF__", sig.arity);
+		func = gExtender->GetServer().Osiris().LookupFunction(sig.name + "__DEF__", sig.arity);
 	}
 
 	if (func == nullptr) {

--- a/BG3Extender/Lua/Server/LuaOsirisBinding.h
+++ b/BG3Extender/Lua/Server/LuaOsirisBinding.h
@@ -57,7 +57,6 @@ TypedValue * LuaToOsi(lua_State * L, int i, ValueType osiType, bool allowNil = f
 void LuaToOsi(lua_State * L, int i, OsiArgumentValue & arg, ValueType osiType, bool allowNil = false, bool reuseStrings = false);
 void OsiToLua(lua_State * L, OsiArgumentValue const & arg);
 void OsiToLua(lua_State * L, TypedValue const & tv);
-Function const* LookupOsiFunction(STDString const& name, uint32_t arity);
 
 class OsiFunction
 {

--- a/BG3Extender/Lua/Server/LuaServer.cpp
+++ b/BG3Extender/Lua/Server/LuaServer.cpp
@@ -131,6 +131,9 @@ namespace bg3se::esv::lua
 		OsiFunctionNameProxy::RegisterMetatable(L);
 		RegisterNameResolverMetatable(L);
 		CreateNameResolver(L);
+		AsyncOsiFunctionNameProxy::RegisterMetatable(L);
+		RegisterAsyncNameResolverMetatable(L);
+		CreateAsyncNameResolver(L);
 	}
 
 

--- a/BG3Extender/Lua/Shared/Proxies/LuaArrayProxy.h
+++ b/BG3Extender/Lua/Shared/Proxies/LuaArrayProxy.h
@@ -18,6 +18,9 @@ BY_VAL(ecs::EntityRef);
 BY_VAL(FixedString);
 BY_VAL(STDString);
 BY_VAL(STDWString);
+BY_VAL(std::monostate);
+BY_VAL(StringView);
+BY_VAL(WStringView);
 #if defined(ENABLE_UI)
 BY_VAL(Noesis::Symbol);
 #endif

--- a/BG3Extender/Osiris/OsirisExtender.h
+++ b/BG3Extender/Osiris/OsirisExtender.h
@@ -38,6 +38,13 @@ public:
 	void LogWarning(std::string_view msg);
 	void LogMessage(std::string_view msg);
 
+	Function const* LookupFunction(const STDString& name, uint32_t arity);
+	
+	inline ValueType GetBaseType(ValueType type)
+	{
+		return (*GetGlobals().Types)->ResolveAlias((uint16_t)type);
+	}
+
 	inline OsirisStaticGlobals const & GetGlobals() const
 	{
 		return wrappers_.Globals;


### PR DESCRIPTION
With the client-side UI manipulation being worked on, I thought it would be a good idea to allow a way for the client to query Osiris state. This adds an asynchronous Osiris interface to both the client and server, which actually allows a client to query Osiris, and also has the same interface for the server if desired. I believe this in conjunction with #199 are very important for full UI support.