### PR TITLE
Renamed placeholder fields on Faction and UserAvatar

### DIFF
--- a/BG3Extender/GameDefinitions/Components/Components.h
+++ b/BG3Extender/GameDefinitions/Components/Components.h
@@ -147,7 +147,7 @@ struct FactionComponent : public BaseComponent
 	EntityHandle field_0;
 	Guid field_8;
 	Guid field_18;
-	EntityHandle field_28;
+	[[bg3::legacy(field_28)]] EntityHandle SummonOwner;
 };
 
 
@@ -420,7 +420,7 @@ struct UserAvatarComponent : public BaseComponent
 	DEFINE_COMPONENT(UserAvatar, "eoc::user::AvatarComponent")
 
 	int UserID;
-	FixedString field_4;
+	[[bg3::legacy(field_4)]] FixedString OwnerProfileID;
 	uint8_t field_8;
 };
 


### PR DESCRIPTION
On summon entities, Faction.field_28 is the entity that owns that summon. On player characters, UserAvatar.field_4 is the player's profile ID UUID