### PR TITLE
renamed 3 steering fields

### DIFF
--- a/BG3Extender/GameDefinitions/Components/Runtime.h
+++ b/BG3Extender/GameDefinitions/Components/Runtime.h
@@ -34,10 +34,10 @@ struct SteeringComponent : public BaseComponent
 	DEFINE_COMPONENT(Steering, "eoc::SteeringComponent")
 
 	glm::vec3 field_0;
-	float field_C;
-	float field_10;
+	[[bg3::legacy(field_C)]] float YAngle;
+	[[bg3::legacy(field_10)]] float XAngle;
 	uint8_t field_14;
-	float field_18;
+	[[bg3::legacy(field_18)]] float ZAngle;
 	uint8_t field_1C;
 };
 


### PR DESCRIPTION
in the steering component :
field_C is the rotation around the Y axis (it's honestly the only one important)
field_10 is the rotation around the X axis (it's almost always ~1/2 pi because you are looking perpendiculary at almost all times)
field_18 is the rotation around the Z axis (it's always 1 because you character litteraly never turns around this axis, I was thinking it'd be 0 always at first but 1 makes sense too)

all angles are in radian, values ranging from 0 to 2pi. I confirmed this and I use it actively in my mod and it works perfectly.

I'm not completely sure about the field_18, but since it's the only one left with a float value I'm pretty sure I'm correct. It's hard to test tho.

The first two are like a 100% guarantee. 

I'm full pepega about github tbh so I might just make something wrong idk xd sorry if that's the case. Also, I tried to copy the formatting of other PR about renamed fields, so I changed only those 3 fields because I'm really not sure what I should be doing.

