### PR TITLE
YAxisRot

### DIFF
--- a/BG3Extender/GameDefinitions/Components/Runtime.h
+++ b/BG3Extender/GameDefinitions/Components/Runtime.h
@@ -34,7 +34,7 @@ struct SteeringComponent : public BaseComponent
 	DEFINE_COMPONENT(Steering, "eoc::SteeringComponent")
 
 	glm::vec3 field_0;
-	float field_C;
+	[[bg3::legacy(field_C)]] float YAxisRot;
 	float field_10;
 	uint8_t field_14;
 	float field_18;


### PR DESCRIPTION
Since my last PR was wrong, I'll only change the one component i'm 100% sure about.
changed Steering.field_C to Steering.YAxisRot. It's the angle in radian, determining one character's rotation around the Y Axis (the vertical one).
If you face straight south, it's 0 (close to 0 if you approach it from the west, close to 2pi if you approach it from the east). If you face straight west, it's pi/2. If you face straight north it's pi. And if you face straight east it's 3/2pi.