### PR TITLE
Update Boosts.h

### DIFF
--- a/BG3Extender/GameDefinitions/Components/Boosts.h
+++ b/BG3Extender/GameDefinitions/Components/Boosts.h
@@ -31,7 +31,7 @@ struct BoostInfoComponent : public BaseComponent
 {
 	DEFINE_COMPONENT(BoostInfo, "eoc::BoostInfoComponent")
 
-	Guid field_10;
+	[[bg3::legacy(field_10)]] Guid CauseUuid;
 	uint8_t field_20;
 	BoostSource Cause;
 	EntityHandle Owner;


### PR DESCRIPTION
renamed BoostInfo.field_10 to CauseUuid (since it is the uuid of the cause...). Found it this morning on lariano's scripting channel.