### PR TITLE
Ensure the GameDefinitions/Generated directory exists before writing.

### DIFF
--- a/BG3Extender/make_enumerations.py
+++ b/BG3Extender/make_enumerations.py
@@ -72,6 +72,8 @@ for file in os.listdir('GameDefinitions/ExternalEnumerations'):
 
 cur_enumerations = ''
 try:
+    if not os.path.exists('GameDefinitions/Generated'):
+        os.mkdir('GameDefinitions/Generated')
     with open('GameDefinitions/Generated/Enumerations.inl', 'r') as f:
         cur_enumerations = f.read()
 except FileNotFoundError:

--- a/BG3Extender/make_property_map.py
+++ b/BG3Extender/make_property_map.py
@@ -699,6 +699,9 @@ try:
 except FileNotFoundError:
     pass
 
+if not os.path.exists('GameDefinitions/Generated'):
+    os.mkdir('GameDefinitions/Generated')
+
 if cur_names != propmap_names + preprocessor.names:
     with open('GameDefinitions/Generated/PropertyMapNames.inl', 'w') as f:
         f.write(propmap_names + preprocessor.names)


### PR DESCRIPTION
This occurred while setting up a fresh clone on the laptop. When generating prototypes, create the GameDefinitions/Generated directory if it doesn't exist.