### PR TITLE
Add MacOS support for BG3 SE

### DIFF
--- a/BG3Extender/Extender/Client/ScriptExtenderClient.h
+++ b/BG3Extender/Extender/Client/ScriptExtenderClient.h
@@ -84,4 +84,33 @@ private:
 	void ShowVersionNumber();
 };
 
+#if defined(__APPLE__)
+class MacOSScriptExtender : public ScriptExtender
+{
+public:
+    MacOSScriptExtender(ExtenderConfig& config);
+
+    void Initialize();
+    void PostStartup();
+    void Shutdown();
+
+    bool IsInClientThread() const;
+    void ResetLuaState();
+    void ResetExtensionState();
+    void LoadExtensionState(ExtensionStateContext ctx);
+
+    void UpdateServerProgress(STDString const& status);
+    void UpdateClientProgress(STDString const& status);
+    void OnGameStateChanged(GameState fromState, GameState toState);
+
+private:
+    void OnBaseModuleLoaded(void * self);
+    void GameStateWorkerWrapper(void (*wrapped)(void*), void* self);
+    void OnUpdate(void* self, GameTime* time);
+    void OnIncLocalProgress(void* self, int progress, char const* state);
+    void ShowLoadingProgress();
+    void ShowVersionNumber();
+};
+#endif
+
 END_NS()

--- a/BG3Extender/Extender/Shared/ExtenderNet.h
+++ b/BG3Extender/Extender/Shared/ExtenderNet.h
@@ -65,4 +65,22 @@ protected:
 	virtual void ProcessExtenderMessage(net::MessageContext& context, MessageWrapper & msg) = 0;
 };
 
+#if defined(__APPLE__)
+class MacOSExtenderProtocol : public ExtenderProtocolBase
+{
+public:
+    ~MacOSExtenderProtocol() override;
+
+    ProtocolResult ProcessMsg(void * unused, MessageContext * unknown, Message* usg) override;
+    ProtocolResult PreUpdate(GameTime const& time) override;
+    ProtocolResult PostUpdate(GameTime const& time) override;
+    void OnAddedToHost() override;
+    void OnRemovedFromHost() override;
+    void Reset() override;
+
+protected:
+    void ProcessExtenderMessage(net::MessageContext& context, MessageWrapper & msg) override;
+};
+#endif
+
 END_NS()

--- a/BG3Extender/Extender/Shared/Hooks.cpp
+++ b/BG3Extender/Extender/Shared/Hooks.cpp
@@ -67,4 +67,66 @@ void Hooks::OnClientConnectMessage(net::Message::SerializeProc* wrapped, net::Me
 	wrapped(msg, serializer);
 }
 
+#if defined(__APPLE__)
+void MacOSHooks::Startup()
+{
+    if (loaded_) {
+        return;
+    }
+
+    auto& lib = gExtender->GetEngineHooks();
+    lib.RPGStats__PreParseDataFolder.SetWrapper(&MacOSHooks::OnParseDataFolder, this);
+    eocnet__ClientConnectMessage__Serialize.SetWrapper(&MacOSHooks::OnClientConnectMessage, this);
+
+    loaded_ = true;
+}
+
+void MacOSHooks::HookNetworkMessages(net::MessageFactory* factory)
+{
+    if (networkingInitialized_) {
+        return;
+    }
+
+    if (factory->MessagePools.size() <= (unsigned)NetMessage::NETMSG_CLIENT_CONNECT) {
+        ERR("MessageFactory not initialized yet");
+        return;
+    }
+
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+
+    auto clientConnect = factory->MessagePools[(unsigned)NetMessage::NETMSG_CLIENT_CONNECT]->Template;
+    eocnet__ClientConnectMessage__Serialize.Wrap((*(net::Message::VMT**)clientConnect)->Serialize);
+
+    DetourTransactionCommit();
+
+    networkingInitialized_ = true;
+}
+
+void MacOSHooks::OnParseDataFolder(stats::RPGStats::ParseStructureFolderProc* next, stats::RPGStats* self, Array<STDString>* paths)
+{
+    LuaVirtualPin lua(gExtender->GetCurrentExtensionState());
+    if (lua) {
+        lua->OnStatsStructureLoaded();
+    }
+
+    {
+        DisableCrashReporting _;
+        next(self, paths);
+    }
+
+    gExtender->GetStatLoadOrderHelper().OnLoadFinished();
+}
+
+void MacOSHooks::OnClientConnectMessage(net::Message::SerializeProc* wrapped, net::Message* msg, net::BitstreamSerializer* serializer)
+{
+    auto m = (net::ClientConnectMessage*)msg;
+    if (serializer->IsWriting) {
+        gExtender->GetClient().GetNetworkManager().OnClientConnectMessage(m);
+    }
+
+    wrapped(msg, serializer);
+}
+#endif
+
 END_SE()

--- a/BG3Extender/Extender/Shared/Hooks.h
+++ b/BG3Extender/Extender/Shared/Hooks.h
@@ -25,4 +25,20 @@ private:
 	bool networkingInitialized_{ false };
 };
 
+#if defined(__APPLE__)
+class MacOSHooks : public Hooks
+{
+public:
+    void Startup();
+    void HookNetworkMessages(net::MessageFactory* factory);
+
+    void OnParseDataFolder(stats::RPGStats::ParseStructureFolderProc* next, stats::RPGStats* self, Array<STDString>* paths);
+    void OnClientConnectMessage(net::Message::SerializeProc* wrapped, net::Message* msg, net::BitstreamSerializer* serializer);
+
+private:
+    bool loaded_{ false };
+    bool networkingInitialized_{ false };
+};
+#endif
+
 END_SE()

--- a/BG3Extender/Extender/Shared/ScriptHelpers.cpp
+++ b/BG3Extender/Extender/Shared/ScriptHelpers.cpp
@@ -124,4 +124,18 @@ bool SaveExternalFile(std::string_view path, PathRootType root, std::string_view
 	return true;
 }
 
+#if defined(__APPLE__)
+bool IsMacOS() {
+    return true;
+}
+
+bool IsAppleSilicon() {
+#if defined(__arm64__) || defined(__aarch64__)
+    return true;
+#else
+    return false;
+#endif
+}
+#endif
+
 }

--- a/BG3Extender/Extender/Shared/ScriptHelpers.h
+++ b/BG3Extender/Extender/Shared/ScriptHelpers.h
@@ -12,4 +12,10 @@ namespace bg3se::script {
 	bool GetTranslatedStringFromKey(FixedString const& key, TranslatedString& translated);
 	bool CreateTranslatedStringKey(FixedString const& key, FixedString const& handle);
 	bool CreateTranslatedString(FixedString const& handle, STDString const& string);
+
+#if defined(__APPLE__)
+    // MacOS-specific script helpers
+    bool IsMacOS();
+    bool IsAppleSilicon();
+#endif
 }

--- a/BG3Extender/Extender/Shared/Utils.cpp
+++ b/BG3Extender/Extender/Shared/Utils.cpp
@@ -24,4 +24,18 @@ void LogOsirisMsg(std::string_view msg)
 	gExtender->LogOsirisMsg(msg);
 }
 
+#if defined(__APPLE__)
+bool IsMacOS() {
+    return true;
+}
+
+bool IsAppleSilicon() {
+#if defined(__arm64__) || defined(__aarch64__)
+    return true;
+#else
+    return false;
+#endif
+}
+#endif
+
 END_SE()

--- a/BG3Extender/Extender/Shared/Utils.h
+++ b/BG3Extender/Extender/Shared/Utils.h
@@ -72,4 +72,9 @@ struct DisableCrashReporting
 	DisableCrashReporting& operator = (DisableCrashReporting const&) = delete;
 };
 
+#if defined(__APPLE__)
+bool IsMacOS();
+bool IsAppleSilicon();
+#endif
+
 END_SE()

--- a/BG3Extender/Extender/Shared/VirtualTextures.h
+++ b/BG3Extender/Extender/Shared/VirtualTextures.h
@@ -24,4 +24,16 @@ private:
 	void RebuildIfNecessary();
 };
 
+#if defined(__APPLE__)
+class MacOSVirtualTextureHelpers : public VirtualTextureHelpers
+{
+public:
+    void Load();
+    bool Stitch();
+    HashMap<FixedString, FixedString> CollectRemaps();
+    bool NeedsRebuild(std::unordered_set<FixedString> const& newTileSets);
+    void RebuildIfNecessary();
+};
+#endif
+
 END_SE()

--- a/BG3Extender/Extender/Shared/VirtualTextures.inl
+++ b/BG3Extender/Extender/Shared/VirtualTextures.inl
@@ -188,4 +188,190 @@ bool VirtualTextureHelpers::Stitch()
 	}
 }
 
+#if defined(__APPLE__)
+void MacOSVirtualTextureHelpers::Load()
+{
+	std::lock_guard _(lock_);
+
+	RebuildIfNecessary();
+
+	auto pendingRemaps = gtsPaths_;
+
+	auto banks = GetStaticSymbols().GetCurrentResourceBank();
+	auto vtManager = (*GetStaticSymbols().ls__gGlobalResourceManager)->VirtualTextureManager;
+	auto bank = banks->Container.Banks[(unsigned)ResourceBankType::VirtualTexture];
+	resource::VirtualTextureResource* firstTex{ nullptr };
+
+	for (auto const& res : bank->Resources) {
+		auto tex = static_cast<resource::VirtualTextureResource*>(res.Value);
+		firstTex = tex;
+		auto remap = pendingRemaps.try_get(tex->GTexFileName);
+		if (remap) {
+			auto gtsGuid = gtsToGuid_.try_get(*remap);
+			if (gtsGuid == nullptr) {
+				auto newGuid = Guid::Generate();
+				gtsGuid = gtsToGuid_.set(*remap, newGuid);
+				auto path = *GetStaticSymbols().ls__PathRoots[(unsigned)PathRootType::Data];
+				path += "/";
+				path += remap->GetStringView();
+				vtManager->TileSets.set(newGuid, path);
+			}
+
+			tex->TileSetFileName = FixedString(gtsGuid->ToString());
+			pendingRemaps.remove(tex->GTexFileName);
+		}
+	}
+
+	if (firstTex != nullptr) {
+		firstTex->Load(*GetStaticSymbols().ls__gGlobalResourceManager);
+	}
+
+	for (auto const& remap : pendingRemaps) {
+		WARN("No resource found for virtual texture with GTexName '%s', can't remap", remap.Key().GetString());
+	}
+}
+
+void MacOSVirtualTextureHelpers::RebuildIfNecessary()
+{
+	auto remaps = CollectRemaps();
+
+	std::unordered_set<FixedString> gtsFiles;
+	for (auto const& path : remaps) {
+		gtsFiles.insert(path.Value());
+	}
+
+	// Check if we need to rebuild, or the merged set already matches the requested one
+	if (built_ && !NeedsRebuild(gtsFiles)) {
+		DEBUG("Merged tileset is already up to date, skipping build");
+		return;
+	}
+
+	gtsPaths_ = std::move(remaps);
+	sourceTileSets_ = gtsFiles;
+	built_ = false;
+
+	if (gtsPaths_.size() > 0) {
+		DEBUG("Loaded %d virtual texture mappings", gtsPaths_.size());
+	}
+
+	if (sourceTileSets_.size() > 1) {
+		built_ = Stitch();
+		if (!built_) {
+			gtsPaths_.clear();
+			sourceTileSets_.clear();
+		}
+	}
+}
+
+bool MacOSVirtualTextureHelpers::NeedsRebuild(std::unordered_set<FixedString> const& newTileSets)
+{
+	if (newTileSets.size() != sourceTileSets_.size()) {
+		return true;
+	}
+
+	for (auto const& path : newTileSets) {
+		if (sourceTileSets_.find(path) == sourceTileSets_.end()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+HashMap<FixedString, FixedString> MacOSVirtualTextureHelpers::CollectRemaps()
+{
+	HashMap<FixedString, FixedString> remaps;
+
+	auto modManager = GetStaticSymbols().GetModManagerClient();
+	for (auto const& mod : modManager->BaseModule.LoadOrderedModules) {
+		auto virtualTextureConfig = "Mods/" + mod.Info.Directory + "/ScriptExtender/VirtualTextures.json";
+		auto reader = GetStaticSymbols().MakeFileReader(virtualTextureConfig);
+
+		if (reader.IsLoaded()) {
+			DEBUG("Loading virtual texture mappings: %s", virtualTextureConfig.c_str());
+
+			Json::CharReaderBuilder factory;
+			auto jsonReader = std::unique_ptr<Json::CharReader>(factory.newCharReader());
+
+			Json::Value root;
+			std::string errs;
+			auto configText = reader.ToString();
+			if (!jsonReader->parse(configText.c_str(), configText.c_str() + configText.size(), &root, &errs)) {
+				OsiError("Unable to parse virtual texture configuration for mod '" << mod.Info.Name << "': " << errs);
+			} else {
+				auto mappings = root["Mappings"];
+				if (mappings.isArray()) {
+					for (auto const& mapping : mappings) {
+						if (mapping.isObject() && mapping["GTexName"].isString() && mapping["GTS"].isString()) {
+							auto gTex = mapping["GTexName"].asString();
+							auto gts = mapping["GTS"].asString();
+							if (!gTex.empty() && !gts.empty()) {
+								remaps.set(FixedString(gTex), FixedString(gts));
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return remaps;
+}
+
+bool MacOSVirtualTextureHelpers::Stitch()
+{
+	if (sourceTileSets_.size() < 2) {
+		// No need to stitch if we only have 1 tile set
+		ERR("Trying to stitch VT with only a single tile set loaded?");
+		return false;
+	}
+
+	DEBUG("Creating merged virtual texture tile set");
+
+	vt::GTSStitchedFile stitched;
+	for (auto const& path : sourceTileSets_) {
+		auto reader = GetStaticSymbols().MakeFileReader(path, PathRootType::Data);
+		if (reader.IsLoaded()) {
+			auto gts = GameAlloc<vt::GTSFile>();
+			gts->Path = path;
+			gts->Buf.resize((uint32_t)reader.Size());
+			std::copy(reinterpret_cast<uint8_t*>(reader.Buf()), reinterpret_cast<uint8_t*>(reader.Buf()) + reader.Size(), gts->Buf.begin());
+			char const* reason{ nullptr };
+			if (!gts->Read(reason)) {
+				ERR("Failed to load '%s': %s", path.GetString(), reason ? reason : "");
+			} else {
+				stitched.TileSets.push_back(gts);
+			}
+		}
+	}
+
+	vt::MergedTileSetGeometryCalculator geom;
+	geom.TileSets = stitched.TileSets;
+	if (!geom.DoAutoPlacement()) {
+		ERR("Failed to calculate merged tileset geometry, virtual textures will not be available!");
+		return false;
+	}
+
+	DEBUG("Merged geometry: %d x %d tiles (%d x %d px)",
+		geom.TotalWidth, geom.TotalHeight,
+		geom.TotalWidth * 128, geom.TotalHeight * 128
+	);
+
+	stitched.Init(geom.TotalWidth, geom.TotalHeight);
+	if (stitched.Build()) {
+		DEBUG("Built merged GTS: %s", stitched.OutputPath.c_str());
+
+		FixedString outputPath{ stitched.OutputPath };
+		for (auto& path : gtsPaths_) {
+			path.Value() = outputPath;
+		}
+
+		return true;
+	} else {
+		ERR("Merged tile set build failed, virtual textures will not be available!");
+		return false;
+	}
+}
+#endif
+
 END_SE()

--- a/BG3Extender/GameHooks/BinaryMappings.xml
+++ b/BG3Extender/GameHooks/BinaryMappings.xml
@@ -975,4 +975,607 @@
       <Target Type="Indirect" Offset="@ref2" Symbol="eoc__AiGrid__FindPathImmediate" />
     </Mapping>
   </Mappings>
-</BinaryMappings>
+
+  <Mappings Version="4.47.63.76" Platform="MacOS" Default="true">
+    <DllImport Module="libSystem.B.dylib" Proc="open" Symbol="libc_open" />
+    <DllImport Module="libSystem.B.dylib" Proc="close" Symbol="libc_close" />
+    <DllImport Module="libSystem.B.dylib" Proc="read" Symbol="libc_read" />
+    <DllImport Module="libSystem.B.dylib" Proc="write" Symbol="libc_write" />
+
+    <Mapping Name="ls__GlobalAllocator" Critical="true">
+      48 89 5c 24 08 // mov     [rsp+arg_0], rbx
+      57 // push    rdi
+      48 83 ec 30 // sub     rsp, 30h
+      48 8b d9 // mov     rbx, rcx
+      83 79 08 00 // cmp     dword ptr [rcx+8], 0
+      74 47 // jz      short loc_14052B63A
+      83 79 0c 00 // cmp     dword ptr [rcx+0Ch], 0
+      7e 07 // jle     short loc_14052B600
+      c7 41 0c 00 00 00 00 // mov     dword ptr [rcx+0Ch], 0
+      48 8b 39 // mov     rdi, [rcx]
+      48 85 ff // test    rdi, rdi
+      74 10 // jz      short loc_14052B618
+      @ref1 e8 ?? ?? ?? ?? // call    ls__GlobalAllocator__Get
+      48 8b d7 // mov     rdx, rdi; a2
+      48 8b c8 // mov     rcx, rax; a1
+      @ref2 e8 ?? ?? ?? ?? // call    ls__GlobalAllocator__Free
+      @ref3 e8 ?? ?? ?? ?? // call    ls__GlobalAllocator__Get
+      48 c7 44 24 20 10 00 00 00 // mov     [rsp+38h+var_18], 10h
+      33 d2 // xor     edx, edx
+      48 8b c8 // mov     rcx, rax
+      @ref4 e8 ?? ?? ?? ?? // call    ls__GlobalAllocator__Alloc
+      48 89 03 // mov     [rbx], rax
+      c7 43 08 00 00 00 00 // mov     dword ptr [rbx+8], 0
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__GlobalAllocator__Get" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="ls__GlobalAllocator__Free" />
+      <Target Type="Indirect" Offset="@ref4" Symbol="ls__GlobalAllocator__Alloc" />
+    </Mapping>
+
+    <Mapping Name="ls::FixedString::IncRef" Critical="true">
+      83 f8 ff // cmp     eax, 0FFFFFFFFh
+      74 0b // jz      short loc_140EC1A4F
+      8b c8 // mov     ecx, eax; a1
+      @ref1 e8 ?? ?? ?? ?? // call    ls__FixedString__AddRef
+      8b 44 24 58 // mov     eax, [rsp+48h+a1]
+      8b 0b // mov     ecx, [rbx]
+      83 f9 ff // cmp     ecx, 0FFFFFFFFh
+      74 20 // jz      short loc_140EC1A76
+      89 4c 24 20 // mov     [rsp+48h+var_28], ecx
+      @ref2 48 8b 0d ?? ?? ?? ?? // mov     rcx, cs:ls__gGlobalStringTable
+      48 81 c1 00 c6 00 00 // add     rcx, 0C600h
+      48 8d 54 24 20 // lea     rdx, [rsp+48h+var_28]
+      @ref3 e8 ?? ?? ?? ?? // call    ls__GlobalStringTable__MainTable__DecRef
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__FixedString__IncRef" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="ls__gGlobalStringTable" />
+      <Target Type="Indirect" Offset="@ref3" Symbol="ls__GlobalStringTable__MainTable__DecRef" />
+    </Mapping>
+
+    <Mapping Name="ls::FixedString::CreateFromString" Critical="true">
+      @str1 48 8d 05 ?? ?? ?? ?? // lea     rax, aH8e3f9e82g8fdag437cg99c1g4988a6aeccff; "h8e3f9e82g8fdag437cg99c1g4988a6aeccff"
+      48 89 44 24 28 // mov     [rsp+58h+a3.Str], rax
+      c7 44 24 30 25 00 00 00 // mov     [rsp+58h+a3.Length], 25h ; '%'
+      c7 44 24 78 ff ff ff ff // mov     [rsp+58h+arg_18], 0FFFFFFFFh
+      c7 44 24 20 02 00 00 00 // mov     [rsp+58h+var_38], 2
+      48 8b 0d ?? ?? ?? ?? // mov     rcx, cs:ls__gGlobalStringTable
+      48 81 c1 00 c6 00 00 // add     rcx, 0C600h; a1
+      4c 8d 44 24 28 // lea     r8, [rsp+58h+a3]; a3
+      48 8d 54 24 70 // lea     rdx, [rsp+58h+a1]; a2
+      @ref2 e8 ?? ?? ?? ?? // call    ls__GlobalStringTable__MainTable__FromString
+      <Condition Type="String" Offset="@str1" Value="h8e3f9e82g8fdag437cg99c1g4988a6aeccff" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="ls__GlobalStringTable__MainTable__CreateFromString" />
+    </Mapping>
+
+    <Mapping Name="ls::FixedString::GetString" Critical="true">
+      48 8d 54 24 40 // lea     rdx, [rsp+58h+var_18]; a2
+      48 8b d8 // mov     rbx, rax
+      @ref1 e8 ?? ?? ?? ?? // call    ls__FixedString__ToString
+      0f 10 07 // movups  xmm0, xmmword ptr [rdi]
+      0f 11 05 ?? ?? ?? ?? // movups  cs:xmmword_145B17160, xmm0
+      0f 10 0b // movups  xmm1, xmmword ptr [rbx]
+      48 8b 5c 24 60 // mov     rbx, [rsp+58h+arg_0]
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__FixedString__GetString" />
+    </Mapping>
+
+    <Mapping Name="ls::FileReader::ctor" Critical="true">
+      48 03 d3 // add     rdx, rbx
+      @str1 4c 8d 05 ?? ?? ?? ?? // lea     r8, aItemcombosTxt; "ItemCombos.txt"
+      48 8d 8d b0 01 00 00 // lea     rcx, [rbp+1B0h]
+      e8 ?? ?? ?? ?? // call    sub_140E37FE0
+      90 // nop
+      45 8b ce // mov     r9d, r14d
+      45 8b c7 // mov     r8d, r15d
+      48 8d 95 b0 01 00 00 // lea     rdx, [rbp+1B0h]
+      48 8d 8d 80 00 00 00 // lea     rcx, [rbp+80h]
+      @ref1 e8 ?? ?? ?? ?? // call    ls__FileReader__ctor
+      <Condition Type="String" Offset="@str1" Value="ItemCombos.txt" />
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__FileReader__ctor" />
+    </Mapping>
+
+    <Mapping Name="ls::FileReader::dtor" Critical="true">
+      48 63 c6 // movsxd  rax, esi
+      48 8d 1c c0 // lea     rbx, [rax+rax*8]
+      48 c1 e3 04 // shl     rbx, 4
+      48 03 1f // add     rbx, [rdi]
+      48 8b cb // mov     rcx, rbx
+      @ref1 e8 ?? ?? ?? ?? // call    ls__FileReader__dtorIntenal
+      48 8d 4b 28 // lea     rcx, [rbx+28h]; a1
+      e8 ?? ?? ?? ?? // call    ls__ScratchBuffer__dtor
+      8b 47 0c // mov     eax, [rdi+0Ch]
+      ff c6 // inc     esi
+      3b f0 // cmp     esi, eax
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__FileReader__dtor" />
+    </Mapping>
+
+    <Mapping Name="ls__PathRoots" Critical="true">
+      0f b6 81 a6 00 00 00 // movzx   eax, byte ptr [rcx+0A6h]
+      24 fe // and     al, 0FEh
+      24 fd // and     al, 0FDh
+      24 fb // and     al, 0FBh
+      88 81 a6 00 00 00 // mov     [rcx+0A6h], al
+      c7 81 a7 00 00 00 04 00 00 00 // mov     dword ptr [rcx+0A7h], 4
+      48 81 c1 b0 00 00 00 // add     rcx, 0B0h ; '°'; a1
+      @ref1 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:cpath_Roots
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__PathRoots" />
+    </Mapping>
+
+    <Mapping Name="App::UpdatePaths">
+      @ref1 e8 ?? ?? ?? ?? // call    App__UpdatePaths
+      @ref2 48 8d 15 ?? ?? ?? ?? // lea     rdx, Locale; Locale
+      33 c9 // xor     ecx, ecx; Category
+      @ref3 ff 15 ?? ?? ?? ?? // call    cs:_wsetlocale
+      b9 fc ff ff ff // mov     ecx, 0FFFFFFFCh; CodePage
+      @ref4 ff 15 ?? ?? ?? ?? // call    cs:_setmbcp
+      @str1 48 8d 15 ?? ?? ?? ?? // lea     rdx, str_C; "C"
+      b9 04 00 00 00 // mov     ecx, 4; Category
+      <Condition Type="String" Offset="@str1" Value="C" />
+      <Target Type="Indirect" Offset="@ref1" Symbol="App__UpdatePaths" />
+    </Mapping>
+
+    <!-- Sig: reference to strings "gr2", "lsm" -->
+    <Mapping Name="EoCServer2/EoCClient2" Critical="true">
+      48 89 44 24 58 // mov     [rsp+78h+var_20], rax
+      0f b7 f2 // movzx   esi, dx
+      48 8b e9 // mov     rbp, rcx
+      45 33 ff // xor     r15d, r15d
+      @ref1 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:ecl__gEocClient
+      4c 8b b0 98 00 00 00 // mov     r14, [rax+98h]
+      @ref2 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:ls__gGlobalSwitches
+      44 38 b8 ee 00 00 00 // cmp     [rax+0EEh], r15b
+      75 7e // jnz     short loc_1405629BC
+      @ref3 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:esv__gEocServer
+      48 8b b8 a8 00 00 00 // mov     rdi, [rax+0A8h]
+      48 8b 4f 20 // mov     rcx, [rdi+20h]
+      <Target Type="Indirect" Offset="@ref1" Symbol="ecl__EoCClient" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="ls__GlobalSwitches" />
+      <Target Type="Indirect" Offset="@ref3" Symbol="esv__EoCServer" />
+    </Mapping>
+
+    <!-- Sig: reference to strings "gr2", "lsm" -->
+    <Mapping Name="EoCServerUpdateProcs" Critical="true">
+      @ref1 48 8b 3d ?? ?? ?? ?? // mov     rdi, cs:ecl__gEocClient
+      48 8b d3 // mov     rdx, rbx
+      48 8b 8f 98 00 00 00 // mov     rcx, [rdi+98h]
+      e8 ?? ?? ?? ?? // call    sub_141668CD0
+      48 8b d3 // mov     rdx, rbx
+      48 8b 8f 90 01 00 00 // mov     rcx, [rdi+190h]
+      @ref2 e8 ?? ?? ?? ?? // call    ecs__EntityWorld__PreUpdate
+      48 8b d3 // mov     rdx, rbx
+      48 8b 8f 90 00 00 00 // mov     rcx, [rdi+90h]
+      @ref3 e8 ?? ?? ?? ?? // call    ecl__GameStateMachine__Update
+      48 8b d3 // mov     rdx, rbx
+      48 8b 8f 90 01 00 00 // mov     rcx, [rdi+190h]
+      @ref4 e8 ?? ?? ?? ?? // call    ecs__EntityWorld__PostUpdate
+      48 8b 8f a8 00 00 00 // mov     rcx, [rdi+0A8h]
+      48 85 c9 // test    rcx, rcx
+      74 0c // jz      short loc_140520D46
+      48 8b 01 // mov     rax, [rcx]
+      48 8b d3 // mov     rdx, rbx
+      ff 90 f0 00 00 00 // call    qword ptr [rax+0F0h]
+      <Target Type="Indirect" Offset="@ref3" Symbol="ecl__GameStateMachine__Update" />
+      <Target Type="Indirect" Offset="@ref4" Symbol="ecs__EntityWorld__Update" />
+    </Mapping>
+
+    <Mapping Name="ecs__EntityWorld__FlushECBs">
+      48 83 be 00 03 00 00 00 // cmp     qword ptr [rsi+300h], 0
+      74 08 // jz      short loc_143693C93
+      48 8b ce // mov     rcx, rsi
+      @ref1 e8 ?? ?? ?? ?? // call    ecs__EntityWorld__FlushECBs
+      48 8b 5e 30 // mov     rbx, [rsi+30h]
+      8b 46 3c // mov     eax, [rsi+3Ch]
+      48 69 f8 f8 00 00 00 // imul    rdi, rax, 0F8h ; 'ø'
+      48 03 fb // add     rdi, rbx
+      48 3b df // cmp     rbx, rdi
+      <Target Type="Indirect" Offset="@ref1" Symbol="ecs__EntityWorld__FlushECBs" />
+    </Mapping>
+
+    <!-- Sig: reference to string "MoveController" -->
+    <Mapping Name="ls__gTranslatedStringRepository" Critical="true">
+      40 53 // push    rbx
+      48 83 ec 40 // sub     rsp, 40h
+      @ref1 48 8b 0d ?? ?? ?? ?? // mov     rcx, cs:ls__gTranslatedStringRepository
+      @str1 48 8d 05 ?? ?? ?? ?? // lea     rax, aMovecontroller; "MoveController"
+      4c 8d 44 24 28 // lea     r8, [rsp+48h+var_20]
+      <Condition Type="String" Offset="@str1" Value="MoveController" />
+      <Target Type="Indirect" Offset="@ref1" Symbol="ls__gTranslatedStringRepository" />
+    </Mapping>
+
+    <Mapping Name="ecl::EoCClient::HandleError">
+      41 b0 01 // mov     r8b, 1
+      48 8d 54 24 48 // lea     rdx, [rsp+3B0h+var_368]
+      48 8b cf // mov     rcx, rdi
+      @ref1 e8 ?? ?? ?? ?? // call    ecl__EocClient__HandleError
+      90 // nop
+      48 8d 4c 24 38 // lea     rcx, [rsp+3B0h+var_378]
+      e9 3e 01 00 00 // jmp     loc_1416CFC8B
+      48 c7 44 24 38 05 00 00 00 // mov     [rsp+3B0h+var_378], 5
+      44 8b c8 // mov     r9d, eax
+      @str1 4c 8d 05 ?? ?? ?? ?? // lea     r8, a4x; "%.4x"
+      <Condition Type="String" Offset="@str1" Value="%.4x" />
+      <Target Type="Indirect" Offset="@ref1" Symbol="ecl__EoCClient__HandleError" />
+    </Mapping>
+
+    <Mapping Name="ecl__gGameStateEventManager" Critical="true">
+      @str1 48 8d 15 ?? ?? ?? ?? // lea     rdx, aClientStateSwa; "CLIENT STATE SWAP - from: %s, to: %s"
+      48 8d 4c 24 38 // lea     rcx, [rsp+3B0h+var_378]
+      e8 ?? ?? ?? ?? // call    sub_1438650C0
+      45 84 f6 // test    r14b, r14b
+      74 00 // jz      short $+2
+      44 89 6d b0 // mov     dword ptr [rbp+2B0h+var_300], r13d
+      8b 47 08 // mov     eax, [rdi+8]
+      89 45 b4 // mov     dword ptr [rbp+2B0h+var_300+4], eax
+      @ref2 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:ecl__gGameStateEventManager
+      <Condition Type="String" Offset="@str1" Value="CLIENT STATE SWAP - from: %s, to: %s" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="ecl__gGameStateEventManager" />
+    </Mapping>
+
+    <Mapping Name="esv__gGameStateEventManager" Critical="true">
+      @str1 48 8d 15 ?? ?? ?? ?? // lea     rdx, aServerStateSwa; "SERVER STATE SWAP - from: %s, to: %s\n"
+      48 8d 4c 24 30 // lea     rcx, [rsp+98h+var_68]
+      e8 ?? ?? ?? ?? // call    sub_1438650C0
+      40 84 ed // test    bpl, bpl
+      74 00 // jz      short $+2
+      44 89 a4 24 a0 00 00 00 // mov     [rsp+98h+arg_0], r12d
+      8b 47 10 // mov     eax, [rdi+10h]
+      89 84 24 a4 00 00 00 // mov     [rsp+98h+arg_4], eax
+      @ref2 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:esv__gGameStateEventManager
+      <Condition Type="String" Offset="@str1" Value="SERVER STATE SWAP - from: %s, to: %s&#10;" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="esv__gGameStateEventManager" />
+    </Mapping>
+
+    <Mapping Name="esv::GameStateMachine::Update" Critical="true">
+      48 89 03 // mov     [rbx], rax
+      48 8b d3 // mov     rdx, rbx
+      48 8b ce // mov     rcx, rsi
+      e8 ?? ?? ?? ?? // call    esv__GameStateMachine__SetTargetState
+      48 8d 15 ?? ?? ?? ?? // lea     rdx, unk_145C9A298
+      48 8b 8f a0 00 00 00 // mov     rcx, [rdi+0A0h]
+      @ref3 e8 ?? ?? ?? ?? // call    esv__GameStateMachine__Update
+      8b 05 ?? ?? ?? ?? // mov     eax, cs:ls__AnimationBlueprintSystemID
+      48 69 d0 f8 00 00 00 // imul    rdx, rax, 0F8h
+      <Target Type="Indirect" Offset="@ref3" Symbol="esv__GameStateMachine__Update" />
+    </Mapping>
+
+    <Mapping Name="App::LoadGraphicSettings" Critical="true">
+      48 89 5c 24 10 // mov     [rsp+arg_8], rbx
+      57 // push    rdi
+      48 83 ec 60 // sub     rsp, 60h
+      48 8b 05 ?? ?? ?? ?? // mov     rax, cs:__security_cookie
+      48 33 c4 // xor     rax, rsp
+      48 89 44 24 58 // mov     [rsp+68h+var_10], rax
+      48 8b f9 // mov     rdi, rcx
+      ba 04 00 00 00 // mov     edx, 4
+      @str1 4c 8d 05 ?? ?? ?? ?? // lea     r8, aGraphicsetting_0; "graphicSettings.lsx"
+      <Condition Type="String" Offset="@str1" Value="graphicSettings.lsx" />
+      <Target Type="Absolute" Offset="0" Symbol="App__LoadGraphicSettings" />
+    </Mapping>
+
+    <!-- Sig: Ref to esv::platform::MovementSystemID -->
+    <Mapping Name="esv::GameStateThreaded::GameStateWorker::DoWork" Critical="true">
+      48 8b c4 // mov     rax, rsp
+      55 // push    rbp
+      53 // push    rbx
+      56 // push    rsi
+      57 // push    rdi
+      41 54 // push    r12
+      41 56 // push    r14
+      41 57 // push    r15
+      48 8d a8 88 fb ff ff // lea     rbp, [rax-478h]
+      48 81 ec 40 05 00 00 // sub     rsp, 540h
+      0f 29 70 b8 // movaps  xmmword ptr [rax-48h], xmm6
+      0f 29 78 a8 // movaps  xmmword ptr [rax-58h], xmm7
+      48 8b f1 // mov     rsi, rcx
+      48 8b 99 e8 00 00 00 // mov     rbx, [rcx+0E8h]
+      @ref1 ff 15 ?? ?? ?? ?? // call    cs:GetCurrentThreadId
+      <Target Type="Absolute" Offset="0" Symbol="esv__GameStateThreaded__GameStateWorker__DoWork" />
+    </Mapping>
+
+    <Mapping Name="ecl::GameStateThreaded::GameStateWorker::DoWork" Scope="Custom" Critical="true">
+      48 8b c4 // mov     rax, rsp
+      48 89 70 10 // mov     [rax+10h], rsi
+      48 89 78 18 // mov     [rax+18h], rdi
+      <Target Type="Absolute" Offset="0" Symbol="ecl__GameStateThreaded__GameStateWorker__DoWork" />
+    </Mapping>
+
+    <Mapping Name="ecl::GameStateThreaded::GameStateWorker::DoWork - Outer" Critical="true">
+      4C 8D 3D ?? ?? ?? ?? // lea     rbp, aEclGamestateth ; "ecl::GameStateThreaded::GameStateWorker::DoWork"
+      <Condition Type="String" Offset="0" Value="ecl::GameStateThreaded::GameStateWorker::DoWork" />
+      <Target Type="Absolute" Offset="-80" NextSymbol="ecl::GameStateThreaded::GameStateWorker::DoWork" NextSymbolSeekSize="80" />
+    </Mapping>
+
+    <Mapping Name="ls::ModuleSettings::IsModded" AllowFail="true">
+      @str 3B 05 ?? ?? ?? ?? // cmp     eax, cs:dword_145E0D6FC
+      74 05 // jz      short loc_1439AEB6F
+      @ref 40 b7 01 // mov     dil, 1
+      eb 03 // jmp     short loc_1439AEB72
+      40 32 ff // xor     dil, dil
+      83 f8 ff // cmp     eax, 0FFFFFFFFh
+      <Condition Type="FixedString" Offset="@str" Value="d65cf1b6-23a8-f0db-0a56-4b479a559748" />
+      <Patch Type="Absolute" Offset="@ref">
+        40 32 ff
+      </Patch>
+    </Mapping>
+
+    <!--
+            Sig: Only caller to eoc::FunctorList::ExecuteType8
+            - ExecuteType8 refs fs_Surface_Type
+        -->
+    <!--
+        <Mapping Name="esv::PassiveSystem::ExecFunctorsBaseCtx">
+            <Target Type="Indirect" Offset="15" Symbol="eoc__StatsFunctorSet__ExecuteType1" />
+            <Target Type="Indirect" Offset="34" Symbol="eoc__StatsFunctorSet__ExecuteType2" />
+            <Target Type="Indirect" Offset="53" Symbol="eoc__StatsFunctorSet__ExecuteType3" />
+            <Target Type="Indirect" Offset="72" Symbol="eoc__StatsFunctorSet__ExecuteType4" />
+            <Target Type="Indirect" Offset="91" Symbol="eoc__StatsFunctorSet__ExecuteType5" />
+            <Target Type="Indirect" Offset="110" Symbol="eoc__StatsFunctorSet__ExecuteType6" />
+            <Target Type="Indirect" Offset="129" Symbol="eoc__StatsFunctorSet__ExecuteType7" />
+            <Target Type="Indirect" Offset="148" Symbol="eoc__StatsFunctorSet__ExecuteType8" />
+            4C 03 C8 // add     r9, rax
+            41 ?? ??  // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            4D 8B C2 // mov     r8, r10
+            49 8B D3 // mov     rdx, r11
+            48 8B CF // mov     rcx, rdi
+            E8 ?? ?? ?? ?? // call    eoc__FunctorList__xxx
+            E9 ?? ?? 00 00 // jmp     xxx
+
+            48 8D 4C ?? ?? // lea     rcx, [rsp+238h+var_1D8]
+        </Mapping>
+
+        <Mapping Name="eoc::DealDamageFunctor::ApplyDamage Outer">
+            <Condition Type="FixedString" Offset="0" Value="FallDamageDamageType" />
+            <Target Type="Absolute" Offset="0" NextSymbol="eoc::DealDamageFunctor::ApplyDamage" NextSymbolSeekSize="384" />
+            48 8D 15 ?? ?? ?? ?? // lea     rdx, fs_FallDamageDamageType
+            48 8B 88 48 02 00 00 // mov     rcx, [rax+248h]
+            E8 ?? ?? ?? ?? // call    CRPGStats_ExtraData__Get
+            F3 0F 2C C0 // cvttss2si eax, xmm0
+            88 45 ?? // mov     [rbp+450h+var_40B], al
+            44 0F B6 C0 // movzx   r8d, al
+        </Mapping>
+        -->
+
+    <!-- Sig: call from DealDamageFunctor::ApplyDamage, near ref to PassiveSystemID -->
+    <Mapping Name="esv::StatsSystem::ThrowDamageEvent">
+      88 44 24 20 // mov     [rsp+0FE0h+a5], al; a5
+      4c 8d 8d 50 09 00 00 // lea     r9, [rbp+0EE0h+damageAmounts]; damageAmounts
+      4c 8d 85 60 05 00 00 // lea     r8, [rbp+0EE0h+var_980]; hit
+      48 8d 95 40 02 00 00 // lea     rdx, [rbp+0EE0h+temp5]; temp5
+      48 8b 4d 50 // mov     rcx, [rbp+0EE0h+rcx0]; rcx0
+      @ref1 e8 ?? ?? ?? ?? // call    esv__StatsSystem__ThrowEntityDamagedEvent
+      80 bd 66 05 00 00 0a // cmp     [rbp+0EE0h+var_980.CauseType], 0Ah
+      0f 84 9f 01 00 00 // jz      loc_1424F4B27
+      83 bd 60 05 00 00 00 // cmp     [rbp+0EE0h+var_980.TotalDamageDone], 0
+      41 0f 9f c4 // setnle  r12b
+      <Target Type="Indirect" Offset="@ref1" Symbol="esv__StatsSystem__ThrowDamageEvent" />
+    </Mapping>
+
+    <!-- Sig: call from osi::ApplyDamage -->
+    <Mapping Name="eoc::DealDamageFunctor::ApplyDamage">
+      48 8d 4d a0 // lea     rcx, [rbp+50h+var_B0]
+      48 89 4c 24 30 // mov     [rsp+160h+spellId2], rcx; spellId2
+      88 44 24 28 // mov     [rsp+160h+var_138], al; char
+      4c 89 7c 24 20 // mov     [rsp+160h+position], r15; position
+      4d 8b cc // mov     r9, r12; target
+      4d 8b c5 // mov     r8, r13; cause
+      48 8b 7d 80 // mov     rdi, qword ptr [rbp+50h+a2.ID]
+      48 8b d7 // mov     rdx, rdi; functor
+      48 8b 5d 90 // mov     rbx, [rbp+50h+hitResult]
+      48 8b cb // mov     rcx, rbx; hitResult
+      @ref1 e8 ?? ?? ?? ?? // call    esv__ExecuteDamageFunctor
+      90 // nop
+      8b 45 c0 // mov     eax, [rbp+50h+var_B0.baseclass_0.Prototype.ID]
+      83 f8 ff // cmp     eax, 0FFFFFFFFh
+      <Target Type="Indirect" Offset="@ref1" Symbol="stats__DealDamageFunctor__ApplyDamage" />
+    </Mapping>
+
+    <Mapping Name="App::Instance">
+      @str1 48 8d 0d ?? ?? ?? ?? // lea     rcx, aCreatingApp; "Creating App\n"
+      ff 15 ?? ?? ?? ?? // call    cs:OutputDebugStringA
+      b9 c8 01 00 00 // mov     ecx, 1C8h
+      ff 15 ?? ?? ?? ?? // call    cs:malloc
+      4c 8b e0 // mov     r12, rax
+      @ref1 48 89 05 ?? ?? ?? ?? // mov     cs:ls__gApp2, rax
+      48 8b c8 // mov     rcx, rax
+      @ref2 e8 ?? ?? ?? ?? // call    App__ctor
+      <Condition Type="String" Offset="@str1" Value="Creating App&#10;" />
+      <Target Type="Indirect" Offset="@ref1" Symbol="AppInstance" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="App__Ctor" />
+    </Mapping>
+
+    <Mapping Name="esv::SavegameManager">
+      <Target Type="Indirect" Offset="18" Symbol="esv__SavegameManager" />
+      48 89 03 // mov     [rbx], rax
+      4C 8B CB // mov     r9, rbx
+      44 8B 05 ?? ?? ?? ?? // mov     r8d, cs:esv__SurfaceActionIndex
+      BA 15 00 00 00 // mov     edx, 15h
+      48 8B 0D ?? ?? ?? ?? // mov     rcx, cs:esv__gSavegameManager
+      E8 ?? ?? ?? ?? // call    esv__SavegameManager__RegisterFactory
+      90 // nop
+    </Mapping>
+
+    <Mapping Name="stats::Object::SetPropertyString">
+      49 8b 4f 20 // mov     rcx, [r15+20h]; this
+      @str1 3b 05 ?? ?? ?? ?? // cmp     eax, cs:fs_ComboCategory.ID
+      75 0a // jnz     short loc_140EF9214
+      48 8b d1 // mov     rdx, rcx
+      e8 ?? ?? ?? ?? // call    sub_140EF9600
+      eb 0b // jmp     short loc_140EF921F
+      48 8d 54 24 30 // lea     rdx, [rsp+211E0h+propertyName]; propertyName
+      @ref2 e8 ?? ?? ?? ?? // call    stats__Object__SetPropertyString
+      90 // nop
+      <Condition Type="FixedString" Offset="@str1" Value="ComboCategory" />
+      <Target Type="Indirect" Offset="@ref2" Symbol="stats__Object__SetPropertyString" />
+    </Mapping>
+
+    <!-- NOTE: Adjust LibraryManager::BindECSContext after changing this -->
+    <Mapping Name="ecs::StaticContextRegistrant" AllowFail="true">
+      @ref1 0f 11 05 ?? ?? ?? ?? // movups  cs:xmmword_145B2D7A0, xmm0
+      48 8d 05 ?? ?? ?? ?? // lea     rax, ls__ComponentIdInitTemp2
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145B2D798, rax
+      48 8d 05 ?? ?? ?? ?? // lea     rax, qword_145BB7478
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145B2D790, rax
+      48 8b 05 ?? ?? ?? ?? // mov     rax, cs:qword_145BB28B0
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145B2D7B0, rax
+      48 8d 05 ?? ?? ?? ?? // lea     rax, qword_145B2D790
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145BB28B0, rax
+      48 8b 5c 24 40 // mov     rbx, [rsp+38h+arg_0]
+      48 83 c4 30 // add     rsp, 30h
+      5f // pop     rdi
+      c3 // retn
+      48 8d 0d ?? ?? ?? ?? // lea     rcx, dword_145BB5A70
+      e8 ?? ?? ?? ?? // call    _Init_thread_header
+      83 3d ?? ?? ?? ?? ff // cmp     cs:dword_145BB5A70, 0FFFFFFFFh
+      0f 85 7a ff ff ff // jnz     loc_14002E90A
+      @str1 48 8d 05 ?? ?? ?? ?? // lea     rax, aClassLsStringv_1; "class ls::_StringView...
+      <Target Type="Absolute" Offset="@ref1" EngineCallback="BindECSContext" />
+    </Mapping>
+
+    <!-- NOTE: Adjust LibraryManager::BindECSIndex after changing this -->
+    <Mapping Name="ecs::StaticIDRegistrant" AllowFail="true">
+      @ref1 48 8b 05 ?? ?? ?? ?? // mov     rax, cs:ecs__EntityWorld__SystemsContext
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145B2D018, rax
+      48 8d 05 ?? ?? ?? ?? // lea     rax, qword_145B2D000
+      48 89 05 ?? ?? ?? ?? // mov     cs:ecs__EntityWorld__SystemsContext, rax
+      c7 05 ?? ?? ?? ?? ff ff ff 7f // mov     cs:ls__InstancingSystemID, 7FFFFFFFh
+      48 8b 5c 24 40 // mov     rbx, [rsp+38h+arg_0]
+      48 83 c4 30 // add     rsp, 30h
+      5f // pop     rdi
+      c3 // retn
+      48 8d 0d ?? ?? ?? ?? // lea     rcx, dword_145BB51D0
+      e8 ?? ?? ?? ?? // call    _Init_thread_header
+      83 3d ?? ?? ?? ?? ff // cmp     cs:dword_145BB51D0, 0FFFFFFFFh
+      75 90 // jnz     short loc_14002F0A8
+      @str1 48 8d 05 ?? ?? ?? ?? // lea     rax, aClassLsStringv_7; "class ls::_StringView
+      <Target Type="Absolute" Offset="@ref1" EngineCallback="BindECSIndex" />
+    </Mapping>
+
+    <!-- NOTE: Adjust LibraryManager::BindECSStaticStringConstructor after changing this -->
+    <Mapping Name="ecs::StaticStringConstructor" AllowFail="true">
+      @ref1 83 3d ?? ?? ?? ?? ff // cmp     cs:dword_145C08178, 0FFFFFFFFh
+      75 c2 // jnz     short loc_141463440
+      48 8d 05 ?? ?? ?? ?? // lea     rax, aClassLsStringv_4229; "class ls::_StringView...
+      48 89 44 24 20 // mov     qword ptr [rsp+38h+var_18], rax
+      c7 44 24 28 ?? ?? 00 00 // mov     dword ptr [rsp+38h+var_18+8], 6Ch ; 'l'
+      0f 28 44 24 20 // movaps  xmm0, [rsp+38h+var_18]
+      66 0f 7f 44 24 20 // movdqa  [rsp+38h+var_18], xmm0
+      48 8d 54 24 20 // lea     rdx, [rsp+38h+var_18]
+      48 8b cb // mov     rcx, rbx; Src
+      e8 ?? ?? ?? ?? // call    ls__ComponentNameFromSymbolName
+      48 8d 0d ?? ?? ?? ?? // lea     rcx, sub_144BF5630; void (__cdecl *)()
+      e8 ?? ?? ?? ?? // call    atexit
+      90 // nop
+      <Target Type="Absolute" Offset="@ref1" EngineCallback="BindECSStaticStringConstructor" />
+    </Mapping>
+
+    <!-- NOTE: Adjust LibraryManager::BindECSStaticRegistrant after changing this -->
+    <Mapping Name="ecs::StaticIDRegistrant2" AllowFail="true">
+      @ref1 48 8d 05 ?? ?? ?? ?? // lea     rax, ls__model__game__inventory__v0__WieldedComponentID2
+      48 8d 4c 24 20 // lea     rcx, [rsp+38h+var_18]
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145B6FA28, rax
+      e8 ?? ?? ?? ?? // call    ls__SV__ls__model__game__inventory__v0__WieldedComponent
+      0f 10 00 // movups  xmm0, xmmword ptr [rax]
+      48 8b 05 ?? ?? ?? ?? // mov     rax, cs:ls__model__TypeIdContext
+      48 89 05 ?? ?? ?? ?? // mov     cs:qword_145B6FA40, rax
+      48 8d 05 ?? ?? ?? ?? // lea     rax, qword_145B6FA28
+      48 89 05 ?? ?? ?? ?? // mov     cs:ls__model__TypeIdContext, rax
+      0f 11 05 ?? ?? ?? ?? // movups  cs:xmmword_145B6FA30, xmm0
+      c7 05 ?? ?? ?? ?? ff ff ff 7f // mov     cs:ls__model__game__inventory__v0__WieldedComponentID2, 7FFFFFFFh
+      48 83 c4 38 // add     rsp, 38h
+      c3 // retn
+      <Target Type="Absolute" Offset="@ref1" EngineCallback="BindECSStaticRegistrant" />
+    </Mapping>
+
+    <!-- NOTE: Adjust LibraryManager::BindComponentReplicationIDRef after changing this -->
+    <Mapping Name="ecs::ComponentReplicationIDRef" AllowFail="true">
+      @ref1 48 89 05 ?? ?? ?? ?? // mov     cs:ecs__sync__ReplicatedTypeContext, rax
+      c7 05 ?? ?? ?? ?? ff ff ff 7f // mov     cs:eoc__summon__ContainerComponentID, 7FFFFFFFh
+      48 8b 5c 24 40 // mov     rbx, [rsp+38h+arg_0]
+      48 83 c4 30 // add     rsp, 30h
+      5f // pop     rdi
+      c3 // retn
+      48 8d 0d ?? ?? ?? ?? // lea     rcx, dword_145BB9C48
+      @ref3 e8 ?? ?? ?? ?? // call    _Init_thread_header
+      83 3d ?? ?? ?? ?? ff // cmp     cs:dword_145BB9C48, 0FFFFFFFFh
+      75 90 // jnz     short loc_14004DF58
+      @str1 48 8d 05 ?? ?? ?? ?? // lea     rax, aClassLsStringv_309; "class ls::_StringView
+      <Target Type="Absolute" Offset="@ref1" EngineCallback="BindComponentReplicationIDRef" />
+    </Mapping>
+
+    <Mapping Name="KillLauncher" AllowFail="true">
+      b9 dc 95 10 00 // mov     ecx, 1095DCh
+      @ref1 ff 15 ?? ?? ?? ?? // call    cs:SteamAPI_RestartAppIfNecessary
+      84 c0 // test    al, al
+      74 09 // jz      short loc_141187B18
+      33 c9 // xor     ecx, ecx; Code
+      @ref2 ff 15 ?? ?? ?? ?? // call    cs:__imp_exit
+      cc // align 8
+      <Patch Type="Absolute" Offset="@ref1">
+        90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90
+      </Patch>
+    </Mapping>
+
+    <!--
+
+      <Mapping Name="esv::StatusMachine::CreateStatus">
+        <Condition Type="FixedString" Offset="0" Value="STORY_FROZEN" />
+        <Target Name="esv::StatusMachine::CreateStatus" Type="Indirect" Offset="25" Symbol="esv__StatusMachine__CreateStatus" />
+        <Target Name="esv::StatusMachine::ApplyStatus" Type="Indirect" Offset="41" Symbol="esv__StatusMachine__ApplyStatus" />
+        48 8D 15 ?? ?? ?? ?? // lea     rdx, fs_STORY_FROZEN
+        4C 8B 05 ?? ?? ?? ?? // mov     r8, cs:qword_144D7D670
+        48 8B CB // mov     rcx, rbx
+        45 33 C9 // xor     r9d, r9d
+        C6 44 24 20 00 // mov     [rsp+38h+var_18], 0
+        E8 ?? ?? ?? ?? // call    esv__StatusMachine__CreateStatus
+        48 8B D0 // mov     rdx, rax
+        48 8B CB // mov     rcx, rbx
+        48 83 C4 30 // add     rsp, 30h
+        5B // pop     rbx
+        E9 ?? ?? ?? ?? // jmp     esv__StatusMachine__ApplyStatus
+      </Mapping>
+      
+        <Mapping Name="esv::SurfaceActionFactory::AddSurfaceAction" Scope="Custom">
+            <Target Type="Indirect" Offset="6" Symbol="esv__SurfaceManager__AddAction" />
+            49 8B D6 //  mov     rdx, r14
+            48 8B C8 // mov     rcx, rax
+            E8 ?? ?? ?? ?? //


### PR DESCRIPTION
Related to #162

Add MacOS support for BG3 SE.

* Add mappings for MacOS binaries and Apple Silicon processors in `BG3Extender/GameHooks/BinaryMappings.xml`.
* Add MacOS-specific hooks and configurations in `BG3Extender/Extender/ScriptExtender.cpp`.
* Add MacOS-specific implementations in `BG3Extender/Extender/Client/ScriptExtenderClient.cpp`.
* Add MacOS-specific declarations in `BG3Extender/Extender/Client/ScriptExtenderClient.h`.
* Add MacOS-specific networking support in `BG3Extender/Extender/Shared/ExtenderNet.h`.
* Add MacOS-specific hooks in `BG3Extender/Extender/Shared/Hooks.h`.
* Implement MacOS-specific hooks in `BG3Extender/Extender/Shared/Hooks.cpp`.
* Add MacOS-specific script helpers in `BG3Extender/Extender/Shared/ScriptHelpers.h`.
* Implement MacOS-specific script helpers in `BG3Extender/Extender/Shared/ScriptHelpers.cpp`.
* Add MacOS-specific utilities in `BG3Extender/Extender/Shared/Utils.h`.
* Implement MacOS-specific utilities in `BG3Extender/Extender/Shared/Utils.cpp`.
* Add MacOS-specific virtual texture support in `BG3Extender/Extender/Shared/VirtualTextures.h`.
* Implement MacOS-specific virtual texture support in `BG3Extender/Extender/Shared/VirtualTextures.inl`.

