### PR TITLE
Update API.md example for PersistentVars to check nil to avoid overwriting value

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -111,7 +111,9 @@ The Lua state and all local variables are reset after each game reload. For keep
 
 Example:
 ```lua
-PersistentVars = {}
+if not PersistentVars then
+    PersistentVars = {}
+end
 ...
 -- Variable will be restored after the savegame finished loading
 function doStuff()


### PR DESCRIPTION
I spent probably more time than I should have trying to figure out why I had trouble getting `PersistentVars` working, only to eventually realize that the issue was that I was overwriting it unconditionally each time the mod was loaded, which of course caused anything I wrote into it before to be thrown away. In retrospect, it was a bit obvious, but I do think it's a somewhat subtle issue for people to figure out, since it's pretty hard to distinguish between what's going on and what would happen with any global variable without special persistence semantics.

In case it might help future developers, I think updating the example snippet to check for nil before initializing would make sense. Presumably a decent number of people start out by copying the examples directly and then updating them as needed, and if I'm not missing something, it seems like the nil check would be pretty much required in order to actually do anything with the variables being persisted.