### PR TITLE
Add NetChannel API docs

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1,7 +1,7 @@
 
-### BG3SE Lua API v11 Documentation
+### BG3SE Lua API v22 Documentation
 
-### Table of Contents  
+### Table of Contents
  - [Getting Started](#getting-started)
     - [Bootstrap Scripts](#bootstrap-scripts)
  - [Client / Server States](#client-server)
@@ -28,8 +28,8 @@
  - [Stats](#stats)
  - [ECS](#ecs)
  - [Networking](#networking)
-    * [Sending NetMessages](#net-send)
-    * [Listening for NetMessages](#net-receive)
+    * [NetChannel API](#net-channel-api)
+    * [NetChannel Examples](#net-channel-examples)
     * [Utility functions](#net-utils)
  - [Custom Variables](#custom-variables)
  - [Utility functions](#ext-utility)
@@ -37,7 +37,6 @@
  - [Mod Info](#mod-info)
  - [Math Library](#math)
  - [Engine Events](#engine-events)
-
 
 <a id="getting-started"></a>
 ## Getting Started
@@ -760,11 +759,12 @@ Ext.Utils.Print(Ext.Stats.ExtraData.WisdomTierHigh)
 
 
 ## ECS
-
 ### TODO - WIP
 
-<a id="networking"></a>
 ## Networking
+<details>
+<summary><b>Deprecated: NetMessages API</b></summary>
+
 To exchange data between the server and client(s), we use NetMessages. These can be sent and received from either context to facilitate communication. This allows us to share data between the server and the client(s) and vice versa.
 
 <a id="net-send"></a>
@@ -853,6 +853,129 @@ Ext.Events.NetMessage:Subscribe(function(data)
  end  
 end)
 ```
+</details>
+
+<a id="net-channel-api"></a>
+
+## NetChannel API
+
+> This section documents the new **NetChannel API**, which supersedes the legacy/deprecated NetMessage approach.
+
+The NetChannel API provides a small, structured abstraction for request/response and message broadcasting and handling between server/client peers. It makes asynchronous requests easier to write and reason about, and can attach message handlers directly to the named channels.
+
+### Why NetChannel is better than the legacy approach
+
+NetChannel improves ergonomics and safety compared to the deprecated NetMessage API:
+
+- **Structured request/reply semantics** - instead of manually correlating messages and replies with NetMessage subscriptions, `RequestTo*` can accept a callback & receive the reply asynchronously right where you define the request.
+- **Handler attachment per-channel** - handlers are registered per channel and are explicit; there are no loose handlers floating around subscriptions.
+- **Faster local client requests** - old NetMessages were delayed by 1 frame even if the target was the local client (e.g. in single-player).
+
+
+### Quick concepts
+
+* **Channel**: a named communication channel (string identifier).
+* **Request / reply**: send a request and receive a response via a callback.
+* **Message**: a one-way transmission of payload data to the other context (fire-and-forget).
+* **Handlers** assign a *message handler* or *request handler* to a channel; these run when a message/request arrives.
+* **Request callbacks** when you `RequestTo*`, you can pass a callback to receive the reply asynchronously.
+
+---
+
+### API type annotation reference
+
+```lua
+--- Sets a handler for incoming messages (fire-and-forget)
+---@param callback fun(data:table, user:any)
+function NetChannel:SetHandler(callback) end
+
+--- Sets a handler for incoming requests; return a table as the reply
+---@param callback fun(data:table, user:any):table
+function NetChannel:SetRequestHandler(callback) end
+
+--- Send a request to the server; reply arrives via `replyCallback`
+---@param data table
+---@param replyCallback fun(data:table)
+function NetChannel:RequestToServer(data, replyCallback) end
+
+--- Send a request to a client; optionally specify a user and reply callback
+---@param data table
+---@param user integer|Guid
+---@param replyCallback fun(data:table)
+function NetChannel:RequestToClient(data, user, replyCallback) end
+```
+
+<a id="net-channel-examples"></a>
+### Usage patterns and examples
+
+This section provides some pseudo-code examples of how to use the NetChannel API under different scenarios.
+
+#### 1) Server-side handler that calls Osiris using data from the payload
+
+```lua
+-- Server side: handle requests
+Channels = {}
+Channels.TemplateAddTo = Net.CreateChannel(ModuleUUID, "TemplateAddTo")
+
+-- Using SetHandler: note there's no reply callback
+Channels.TemplateAddTo:SetHandler(function(data, user)
+    for _, v in pairs(data.Items) do
+        local template, amount = table.unpack(v)
+        _P("Adding " .. template .. " to " .. data.Target .. " with amount " .. amount)
+        Osi.TemplateAddTo(template, data.Target, amount or 1)
+    end
+end)
+
+-- Client side: send message to server
+Channels.TemplateAddTo:SendToServer({
+    Items = { {"item-template-guid-1", 1}, {"item-template-guid-2", 2} },
+    Target = someEntityId
+})
+```
+
+#### 2) Request / reply (client requests some data from the server)
+
+```lua
+-- Server side: handle requests
+Channels.CanItemBeMoved:SetRequestHandler(function(data, user)
+    local item = Ext.Entity.Get(data.Target)
+    return { Result = item.ServerItem.CanBeMoved }
+end)
+
+-- Client side: send to server and handle reply in the same spot (async)
+local itemUuid = ...
+Channels.CanItemBeMoved:RequestToServer({ Target = itemUuid }, function(response)
+    Log("CanItemBeMoved reply", itemUuid, response.Result)
+end)
+```
+
+This pattern allows the caller to perform work after the reply arrives without storing temporary state elsewhere, or defining multiple NetMessage channels (old API).
+
+#### 3) Broadcast & sync (server pushes global state)
+
+```lua
+-- Client side: message handler for SyncSettings
+Channels.SyncSettings = Net.CreateChannel(ModuleUUID, "SyncSettings")
+Channels.SyncSettings:SetHandler(function(data, user)
+    ModSettings = data.Settings
+    _P("Received mod settings sync from server")
+end)
+
+-- Server side: push current data to all connected clients
+Channels.SyncSettings:Broadcast({ Settings = MCM.GetCurrentSettings() })
+```
+
+#### 4) Targeted messages (server → specific client)
+
+```lua
+-- Server side: send data to a specific client (determined by clientId)
+Channels.ChangeAppearance = Net.CreateChannel(ModuleUUID, "ChangeAppearance")
+local clientId = ...
+Channels.ChangeAppearance:SendToClient({ CCAData = {...} }, clientId)
+```
+
+Only the client of id `clientId` will receive the message.
+
 
 <a id="net-utils"></a>
 ### Utility functions 


### PR DESCRIPTION
Updated documentation to include NetChannel API details and examples. Old NetMessages section is collapsed.

When using the new NetChannel API, can `RequestToServer` / `RequestToClient` be called within the same context (e.g., server → server or client → client)?