### PR TITLE
Map `Lock`'s `field_8` to `LockDifficultyClassID`

### DIFF
--- a/BG3Extender/GameDefinitions/Components/Data.h
+++ b/BG3Extender/GameDefinitions/Components/Data.h
@@ -252,7 +252,7 @@ struct LockComponent : public BaseComponent
 
     FixedString Key_M;
     int LockDC;
-    Guid field_8;
+    [[bg3::legacy(field_8)]] Guid LockDifficultyClassID;
     Array<Guid> field_18;
 };
 

--- a/BG3Extender/IdeHelpers/ExtIdeHelpers.lua
+++ b/BG3Extender/IdeHelpers/ExtIdeHelpers.lua
@@ -5003,8 +5003,8 @@ Osi = {}
 --- @class LockComponent:BaseComponent
 --- @field Key_M FixedString
 --- @field LockDC int32
+--- @field LockDifficultyClassID Guid
 --- @field field_18 Guid[]
---- @field field_8 Guid
 
 
 --- @class LockpickActionData:IActionData


### PR DESCRIPTION
Reference:
`_D(Ext.Entity.Get("fb8f8efe-f0d1-4534-a665-4de548241174").Lock)` (locked chest in Emerald Grove):
```json
{
    "Key_M": "DEN_CartChest_001",
    "LockDC": 32756,
    "field_18": [],
    "field_8": "831e1fbe-428d-4f4d-bd17-4206d6efea35"
}
```
https://bg3.norbyte.dev/search?q=831e1fbe-428d-4f4d-bd17-4206d6efea35#result-b216bc7cb2a13fa7834e1365ed824ed7d89effa2